### PR TITLE
Fixed typo in complex[32]

### DIFF
--- a/source/language/openpulse.rst
+++ b/source/language/openpulse.rst
@@ -350,7 +350,7 @@ extern definition at the top-level, such as:
    extern capture(frame output);
 
    // A capture command that returns an iq value
-   extern capture(waveform filter, frame output) -> complex[32];
+   extern capture(waveform filter, frame output) -> complex[float[32]];
 
    // A capture command that returns a discrimnated bit
    extern capture(waveform filter, frame output) -> bit;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fix typo from `complex[32]` to `complex[float[32]]`