### PR TITLE
update PULL_REQUEST_TEMPLATE.md to include a warning about grammar changes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,13 @@
 ✅ I have added the tests to cover my changes.
 ✅ I have updated the documentation accordingly.
 ✅ I have read the CONTRIBUTING document.
+
+Are you changing the specification? This PR needs to be approved by the TSC members.
+
+Are you changing the grammar to adjust to the specification?
+
+The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.
+
 -->
 
 ### Summary


### PR DESCRIPTION
In order to avoid updates in the grammar out of the specification, a warning in the PR template is added. 