### PR TITLE
Change frame manipulation to use `set`/`shift`/`get` instructions.

### DIFF
--- a/source/language/openpulse.rst
+++ b/source/language/openpulse.rst
@@ -189,7 +189,7 @@ of type ``float``.
   get_frequency(frame fr) -> float;
 
 Changing the frequency or phase behaves as an instantaneous operation (ie., its
-duration is zero device ticks) at the current time point of the frame. If a vendor If a vendor
+duration is zero device ticks) at the current time point of the frame. If a vendor
 is unable to support such instantaneous operations, it is expected that the
 compiler shall raise a compile-time error when encountering such frame manipulations.
 

--- a/source/language/openpulse.rst
+++ b/source/language/openpulse.rst
@@ -164,7 +164,7 @@ the `set_phase` and `shift_phase` instructions allow one to supply the frame and
 .. code-block:: javascript
 
   set_phase(frame fr, angle phase);
-  shift_frequency(frame fr, angle phase);
+  shift_phase(frame fr, angle phase);
 
 The `get_phase` instruction allows one to supply the frame from which to retrieve the phase of
 type ``angle``.
@@ -188,13 +188,14 @@ of type ``float``.
 
   get_frequency(frame fr) -> float;
 
-Changing the frequency or phase is an instantaneous operation. If a vendor
+Changing the frequency or phase behaves as an instantaneous operation (ie., its
+duration is zero device ticks) at the current time point of the frame. If a vendor If a vendor
 is unable to support such instantaneous operations, it is expected that the
 compiler shall raise a compile-time error when encountering such frame manipulations.
 
-Moreover, the exact precision of these calculations is hardware specific. If either the frequency
-or phase are set to values that are invalid for the hardware, the compiler shall raise a
-compile-time error.
+The exact precision and range of the frequency is hardware specific, and it is likely
+hardware vendors will perform a float to fixed conversion in the backend. If the frequency
+is set to an out of bounds value, the compiler shall raise a compile-time error.
 
 Here's an example of manipulating the phase to calibrate an ``rz`` gate on a frame called
 ``driveframe``:
@@ -228,8 +229,8 @@ Manipulating frames based on the state of other frames is also permitted:
 
 .. code-block:: javascript
 
-   const angle temp1 = get_phase(frame1);
-   const angle temp2 = get_phase(frame2);
+   angle temp1 = get_phase(frame1);
+   angle temp2 = get_phase(frame2);
    set_phase(frame1, temp2);
    set_phase(frame2, temp1);
 

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -136,9 +136,9 @@ a global scope to all identifiers in order to declare values shared across all `
    defcal x $0 {
       waveform xp = gaussian(1.0, 160t, 40dt);
       // References frame and `new_freq` declared in top-level cal block
-      play(xp, d0f);
-      set_frequency(new_freq, d0f);
-      play(xp, d0f);
+      play(d0f, xp);
+      set_frequency(d0f, new_freq);
+      play(d0f, xp);
    }
 
 
@@ -208,21 +208,21 @@ existing ``include`` mechanism.
    }
 
    defcal rz(angle theta) $0 {
-      shift_phase(theta, q0_frame);
+      shift_phase(q0_frame, theta);
    }
 
    defcal rz(angle theta) $1 {
-      shift_phase(theta, q1_frame);
+      shift_phase(q1_frame, theta);
    }
 
    defcal sx $0 {
       waveform sx_wf = drag(0.2+0.1im, 160dt, 40dt, 0.05);
-      play(sx_wf, q0_frame);
+      play(q0_frame, sx_wf);
    }
 
    defcal sx $1 {
       waveform sx_wf = drag(0.1+0.05im, 160dt, 40dt, 0.1);
-      play(sx_wf, q1_frame);
+      play(q1_frame, sx_wf);
    }
 
    defcal cx $1, $0 {
@@ -232,14 +232,14 @@ existing ``include`` mechanism.
       rz(pi/2) $0; rz(-pi/2) $1;
       sx $0; sx $1;
       barrier $0, $1;
-      play(CR90p, q0_frame);
+      play(q0_frame, CR90p);
       barrier $0, $1;
       sx $0;
       sx $0;
       barrier $0, $1;
       rz(-pi/2) $0; rz(pi/2) $1;
       sx $0; sx $1;
-      play(CR90m, q0_frame);
+      play(q0_frame, CR90m);
    }
 
 The user would then include the ``backend.inc`` in their own program and use them as demonstrated below
@@ -254,7 +254,7 @@ The user would then include the ``backend.inc`` in their own program and use the
    // to "plugin" to the existing calibrations.
    defcal Y90p $0 {
       waveform y90p = drag(0.1-0.2im, 160dt, 40dt, 0.05);
-      play(y90p, q0_frame);
+      play(q0_frame, y90p);
    }
 
    // Teach the compiler what the unitary of a Y90p is

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -137,7 +137,7 @@ a global scope to all identifiers in order to declare values shared across all `
       waveform xp = gaussian(1.0, 160t, 40dt);
       // References frame and `new_freq` declared in top-level cal block
       play(xp, d0f);
-      frame.frequency = new_freq;
+      set_frequency(new_freq, d0f);
       play(xp, d0f);
    }
 
@@ -208,11 +208,11 @@ existing ``include`` mechanism.
    }
 
    defcal rz(angle theta) $0 {
-      q0_frame.phase += theta;
+      shift_phase(theta, q0_frame);
    }
 
    defcal rz(angle theta) $1 {
-      q1_frame.phase += theta;
+      shift_phase(theta, q1_frame);
    }
 
    defcal sx $0 {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

This is a minor revision to the [OpenPulse specification](https://qiskit.github.io/openqasm/language/openpulse.html) that changes  the current `phase` and `frequency` attributes access style to an extern/subroutine style for more consistency with the other call patterns in _openpulse_ and _openqasm_ . It also the style used in the reference implementation in #352.

### Details and comments

Succinctly, updates to `phase` and `frequency` are changed as follows


```c
drive_frame.frequency = 5.2e9 -> set_frequency(5.2e9, drive_frame);
drive_frame.frequency -= 0.1e9 -> shift_frequency(-0.1e9, drive_frame);
drive_frame.phase = π/2 -> set_phase(π/2, drive_frame);
drive_frame.phase -= π/4 -> shift_phase(-π/2, drive_frame);
```

Reading the `phase` and  `frequency` is changed as follows
```
float my_freq = drive_frame.frequency; 
↓
float my_freq = get_frequency(drive_frame);

angle my_phase = drive_frame.phase;
↓
angle my_phase = get_phase(drive_frame);
```

This also allows for a more consistent way for vendors to extend frame manipulation via `extern`s e.g. 
```c
extern chirp_frequency(float freq, frame fr);
extern swap_phases(frame fr1, frame fr2);
```

cc: @aspcompiler