### PR TITLE
Flesh out compile-time expressions and `const` types

### DIFF
--- a/examples/arrays.qasm
+++ b/examples/arrays.qasm
@@ -80,12 +80,12 @@ const uint[32] first_dimension = sizeof(my_doubles);  // still 8.
 // Arrays in subroutines
 // =====================
 
-// Array arguments have a mandatory ``const`` or ``mutable`` specifier when
+// Array arguments have a mandatory ``readonly`` or ``mutable`` specifier when
 // defined in a subroutine argument list.  This is because arrays are passed to
 // subroutines by reference, not by value, so modifications will propagate back
 // to the original data.  Such modifications are only allowed for ``mutable``
-// references, not ``const``.
-def copy_3_bytes(const array[uint[8], 3] in_array, mutable array[uint[8], 3] out_array) {
+// references, not ``readonly``.
+def copy_3_bytes(readonly array[uint[8], 3] in_array, mutable array[uint[8], 3] out_array) {
     // Within this block, ``in_array`` can be read from, but not written to,
     // whereas ``out_array`` can be both read from and written to.
 }
@@ -94,7 +94,7 @@ def copy_3_bytes(const array[uint[8], 3] in_array, mutable array[uint[8], 3] out
 // the sizes of the dimensions are not given explicitly, only the number of
 // dimensions.  This is where the ``sizeof`` operator is most useful.  In these
 // cases, `sizeof` is _not_ a compile-time constant.
-def multi_dimensional_input(const array[int[32], #dim=3] my_array) {
+def multi_dimensional_input(readonly array[int[32], #dim=3] my_array) {
     uint[32] dimension_0 = sizeof(my_array, 0);
     uint[32] dimension_1 = sizeof(my_array, 1);
     uint[32] dimension_2 = sizeof(my_array, 2);

--- a/source/grammar/qasm3Lexer.g4
+++ b/source/grammar/qasm3Lexer.g4
@@ -42,6 +42,7 @@ AnnotationKeyword: '@' Identifier ->  pushMode(EAT_TO_LINE_END);
 INPUT: 'input';
 OUTPUT: 'output';
 CONST: 'const';
+READONLY: 'readonly';
 MUTABLE: 'mutable';
 
 QREG: 'qreg';

--- a/source/grammar/qasm3Parser.g4
+++ b/source/grammar/qasm3Parser.g4
@@ -198,7 +198,7 @@ scalarType:
 ;
 qubitType: QUBIT designator?;
 arrayType: ARRAY LBRACKET scalarType COMMA expressionList RBRACKET;
-arrayReferenceType: (CONST | MUTABLE) ARRAY LBRACKET scalarType COMMA (expressionList | DIM EQUALS expression) RBRACKET;
+arrayReferenceType: (READONLY | MUTABLE) ARRAY LBRACKET scalarType COMMA (expressionList | DIM EQUALS expression) RBRACKET;
 
 designator: LBRACKET expression RBRACKET;
 

--- a/source/grammar/tests/reference/subroutine/array.yaml
+++ b/source/grammar/tests/reference/subroutine/array.yaml
@@ -1,10 +1,10 @@
 # indent w/ 2 spaces
 source: |
   def test_array_1(mutable array[uint[16], 4, 2] a) {}
-  def test_array_2(const array[uint[16], 4, 2] a) {}
+  def test_array_2(readonly array[uint[16], 4, 2] a) {}
   def test_array_3(mutable array[uint[16], #dim=2] a) {}
-  def test_array_4(const array[uint[16], #dim=2*n] a) {}
-  def test_array_5(const array[int[8], #dim=1] a, mutable array[complex[float[64]], #dim=3] b, const array[complex[float[64]], 2, 2] c) -> int[8] {}
+  def test_array_4(readonly array[uint[16], #dim=2*n] a) {}
+  def test_array_5(readonly array[int[8], #dim=1] a, mutable array[complex[float[64]], #dim=3] b, readonly array[complex[float[64]], 2, 2] c) -> int[8] {}
 reference: |
   program
     statement
@@ -46,7 +46,7 @@ reference: |
         argumentDefinitionList
           argumentDefinition
             arrayReferenceType
-              const
+              readonly
               array
               [
               scalarType
@@ -106,7 +106,7 @@ reference: |
         argumentDefinitionList
           argumentDefinition
             arrayReferenceType
-              const
+              readonly
               array
               [
               scalarType
@@ -139,7 +139,7 @@ reference: |
         argumentDefinitionList
           argumentDefinition
             arrayReferenceType
-              const
+              readonly
               array
               [
               scalarType
@@ -183,7 +183,7 @@ reference: |
           ,
           argumentDefinition
             arrayReferenceType
-              const
+              readonly
               array
               [
               scalarType

--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -89,8 +89,8 @@ Arrays in subroutines
 
 Arrays may be passed as parameters to subroutines and externs. All array
 parameters are passed as references and must include a type modifier specifying
-if the parameter is ``const`` or ``mutable``. The number of dimensions for all
-array parameters must be specified using the ``#dim = literal/const identifier``
+if the parameter is ``readonly`` or ``mutable``. The number of dimensions for all
+array parameters must be specified using the ``#dim = const expression``
 syntax below, or specific lengths for each dimension must be provided.
 The unspecified-length version is provided because the lengths of
 the dimensions of array parameters (in the case of strided access) may not be
@@ -101,8 +101,8 @@ about the order that updates are made in.
 
 .. code-block::
 
-   def specified_sub(const array[int[8], 2, 10] arr_arg) { /* ... */ }
-   def arr_subroutine(const array[int[8], #dim = 1] arr_arg) { /* ... */ }
+   def specified_sub(readonly array[int[8], 2, 10] arr_arg) { /* ... */ }
+   def arr_subroutine(readonly array[int[8], #dim = 1] arr_arg) { /* ... */ }
    def mut_subroutine(mutable array[int[8], #dim = 1] arr_arg) {
      arr_arg[2] = 10; // allowed
      // ...
@@ -131,7 +131,7 @@ subscripted, meaning that ``sizeof(arr[0], 0) == sizeof(arr, 1)``.
 
 .. code-block::
 
-   def arr_subroutine(const array[int[8], #dim = 2] twoD_arg) {
+   def arr_subroutine(readonly array[int[8], #dim = 2] twoD_arg) {
      uint[32] firstDim  = sizeof(twoD_arg, 0);
      uint[32] secondDim = sizeof(twoD_arg, 1);
      int[32] sum = 0;

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -507,64 +507,65 @@ inputs of these functions.
 
    .. table:: Built-in mathematical functions in OpenQASM3.
 
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | Function | Input Range/Type, [...]           | Output Range/Type                    | Notes                                  |
-      +==========+===================================+======================================+========================================+
-      | arccos   | ``float`` on :math:`[-1, 1]`      | ``float`` on :math:`[0, \pi]`        | Inverse cosine.                        |
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | arcsin   | ``float`` on :math:`[-1, 1]`      | ``float`` on :math:`[-\pi/2, \pi/2]` | Inverse sine.                          |
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | arctan   | ``float``                         | ``float`` on :math:`[-\pi/2, \pi/2]` | Inverse tangent.                       |
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | ceiling  | ``float``                         | ``float``                            | Round to the nearest representable     |
-      |          |                                   |                                      | integer equal or greater in value.     |
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | cos      | (``float`` or ``angle``)          | ``float``                            | Cosine.                                |
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | exp      | ``float``                         | ``float``                            | Exponential :math:`e^x`.               |
-      |          |                                   |                                      |                                        |
-      |          | ``complex``                       | ``complex``                          |                                        |
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | floor    | ``float``                         | ``float``                            | Round to the nearest representable     |
-      |          |                                   |                                      | integer equal or lesser in value.      |
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | log      | ``float``                         | ``float``                            | Logarithm base :math:`e`.              |
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | mod      | ``int``, ``int``                  | ``int``                              | Modulus.  The remainder from the       |
-      |          |                                   |                                      | integer division of the first argument |
-      |          | ``float``, ``float``              | ``float``                            | by the second argument.                |
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | popcount | ``bit[_]``                        | ``uint``                             | Number of set (1) bits.                |
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | pow      | ``int``, ``uint``                 | ``int``                              | :math:`\texttt{pow(a, b)} = a^b`.      |
-      |          |                                   |                                      |                                        |
-      |          | ``float``, ``float``              | ``float``                            | For floating-point and complex values, |
-      |          |                                   |                                      | the principal value is returned.       |
-      |          | ``complex``, ``complex``          | ``complex``                          |                                        |
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | rotl     | ``bit[n]``, ``uint``              | ``bit[n]``                           | Rotate the bits in the representation  |
-      |          |                                   |                                      | ``n`` to the left (towards higher      |
-      |          |                                   |                                      | indices).  This is similar to a bit    |
-      |          |                                   |                                      | shift operation, except the vacated    |
-      |          |                                   |                                      | bits are filled from the overflow,     |
-      |          |                                   |                                      | rather than being set to zero.  The    |
-      |          |                                   |                                      | width of the output is set equal to    |
-      |          |                                   |                                      | the width of the input.                |
-      |          |                                   |                                      |                                        |
-      |          |                                   |                                      | ``rotl(a, n) == rotr(a, -n)``.         |
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | rotr     | ``bit[n]``, ``uint``              | ``bit[n]``                           | Rotate the bits in the representation  |
-      |          |                                   |                                      | ``n`` to the right (towards lower      |
-      |          |                                   |                                      | indices).                              |
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | sin      | (``float`` or ``angle``)          | ``float``                            | Sine.                                  |
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | sqrt     | ``float``                         | ``float``                            | Square root.  This always returns the  |
-      |          |                                   |                                      | principal root.                        |
-      |          | ``complex``                       | ``complex``                          |                                        |
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | tan      | (``float`` or ``angle``)          | ``float``                            | Tangent.                               |
-      +----------+-----------------------------------+--------------------------------------+----------------------------------------+
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
+      | Function | Input Range/Type, [...]             | Output Range/Type                    | Notes                                  |
+      +==========+=====================================+======================================+========================================+
+      | arccos   | ``float`` on :math:`[-1, 1]`        | ``float`` on :math:`[0, \pi]`        | Inverse cosine.                        |
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
+      | arcsin   | ``float`` on :math:`[-1, 1]`        | ``float`` on :math:`[-\pi/2, \pi/2]` | Inverse sine.                          |
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
+      | arctan   | ``float``                           | ``float`` on :math:`[-\pi/2, \pi/2]` | Inverse tangent.                       |
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
+      | ceiling  | ``float``                           | ``float``                            | Round to the nearest representable     |
+      |          |                                     |                                      | integer equal or greater in value.     |
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
+      | cos      | (``float`` or ``angle``)            | ``float``                            | Cosine.                                |
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
+      | exp      | ``float``                           | ``float``                            | Exponential :math:`e^x`.               |
+      |          |                                     |                                      |                                        |
+      |          | ``complex``                         | ``complex``                          |                                        |
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
+      | floor    | ``float``                           | ``float``                            | Round to the nearest representable     |
+      |          |                                     |                                      | integer equal or lesser in value.      |
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
+      | log      | ``float``                           | ``float``                            | Logarithm base :math:`e`.              |
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
+      | mod      | ``int``, ``int``                    | ``int``                              | Modulus.  The remainder from the       |
+      |          |                                     |                                      | integer division of the first argument |
+      |          | ``float``, ``float``                | ``float``                            | by the second argument.                |
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
+      | popcount | ``bit[_]``                          | ``uint``                             | Number of set (1) bits.                |
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
+      | pow      | ``int``, ``uint``                   | ``int``                              | :math:`\texttt{pow(a, b)} = a^b`.      |
+      |          |                                     |                                      |                                        |
+      |          | ``float``, ``float``                | ``float``                            | For floating-point and complex values, |
+      |          |                                     |                                      | the principal value is returned.       |
+      |          | ``complex``, ``complex``            | ``complex``                          |                                        |
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
+      | rotl     | ``bit[n] value``, ``int distance``  | ``bit[n]``                           | Rotate the bits in the representation  |
+      |          |                                     |                                      | of ``value`` by ``distance`` places    |
+      |          | ``uint[n] value``, ``int distance`` | ``uint[n]``                          | to the left (towards higher            |
+      |          |                                     |                                      | indices).  This is similar to a bit    |
+      |          |                                     |                                      | shift operation, except the vacated    |
+      |          |                                     |                                      | bits are filled from the overflow,     |
+      |          |                                     |                                      | rather than being set to zero.  The    |
+      |          |                                     |                                      | width of the output is set equal to    |
+      |          |                                     |                                      | the width of the input.                |
+      |          |                                     |                                      |                                        |
+      |          |                                     |                                      | ``rotl(a, n) == rotr(a, -n)``.         |
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
+      | rotr     | ``bit[n] value``, ``int distance``  | ``bit[n]``                           | Rotate the bits in the representation  |
+      |          |                                     |                                      | of ``value`` by ``distance`` places to |
+      |          | ``uint[n] value``, ``int distance`` | ``uint[n]``                          | the right (towards lower indices).     |
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
+      | sin      | (``float`` or ``angle``)            | ``float``                            | Sine.                                  |
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
+      | sqrt     | ``float``                           | ``float``                            | Square root.  This always returns the  |
+      |          |                                     |                                      | principal root.                        |
+      |          | ``complex``                         | ``complex``                          |                                        |
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
+      | tan      | (``float`` or ``angle``)            | ``float``                            | Tangent.                               |
+      +----------+-------------------------------------+--------------------------------------+----------------------------------------+
 
 For each built-in function, the chosen overload is the first one to appear in
 the list above where all given operands can be implicitly cast to the valid
@@ -600,7 +601,7 @@ is an error if there is no valid overload for a given sequence of operands.
    // is not attempted, because it has lower priority.
 
    const bit[8] b2 = rotl(b1, 3);
-   // Value "0101_0001", expression has type `const bit[8]` (the 
+   // Value "0101_0001", expression has type `const bit[8]`.
 
 
    // Invalid statements.

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -542,7 +542,7 @@ inputs of these functions.
       |          |                                   |                                      | the principal value is returned.       |
       |          | ``complex``, ``complex``          | ``complex``                          |                                        |
       +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | rotl     | ``bit[n]``, ``int``               | ``bit[n]``                           | Rotate the bits in the representation  |
+      | rotl     | ``bit[n]``, ``uint``              | ``bit[n]``                           | Rotate the bits in the representation  |
       |          |                                   |                                      | ``n`` to the left (towards higher      |
       |          |                                   |                                      | indices).  This is similar to a bit    |
       |          |                                   |                                      | shift operation, except the vacated    |
@@ -553,7 +553,7 @@ inputs of these functions.
       |          |                                   |                                      |                                        |
       |          |                                   |                                      | ``rotl(a, n) == rotr(a, -n)``.         |
       +----------+-----------------------------------+--------------------------------------+----------------------------------------+
-      | rotr     | ``bit[n]``, ``int``               | ``bit[n]``                           | Rotate the bits in the representation  |
+      | rotr     | ``bit[n]``, ``uint``              | ``bit[n]``                           | Rotate the bits in the representation  |
       |          |                                   |                                      | ``n`` to the right (towards lower      |
       |          |                                   |                                      | indices).                              |
       +----------+-----------------------------------+--------------------------------------+----------------------------------------+

--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -93,7 +93,7 @@ __all__ = [
     "WhileLoop",
 ]
 
-AccessControl = Enum("AccessControl", "const mutable")
+AccessControl = Enum("AccessControl", "readonly mutable")
 AssignmentOperator = Enum("AssignmentOperator", "= += -= *= /= &= |= ~= ^= <<= >>= %= **=")
 BinaryOperator = Enum("BinaryOperator", "> < >= <= == != && || | ^ & << >> + - * / % **")
 GateModifierName = Enum("GateModifier", "inv pow ctrl negctrl")

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -814,7 +814,9 @@ class QASMNodeVisitor(qasm3ParserVisitor):
             )
         elif ctx.arrayReferenceType():
             array_ctx = ctx.arrayReferenceType()
-            access = ast.AccessControl.const if array_ctx.CONST() else ast.AccessControl.mutable
+            access = (
+                ast.AccessControl.readonly if array_ctx.READONLY() else ast.AccessControl.mutable
+            )
             base_type = self.visit(array_ctx.scalarType())
             dimensions = (
                 self.visit(array_ctx.expression())
@@ -838,7 +840,9 @@ class QASMNodeVisitor(qasm3ParserVisitor):
             type_ = self.visit(ctx.scalarType())
         else:
             array_ctx = ctx.arrayReferenceType()
-            access = ast.AccessControl.const if array_ctx.CONST() else ast.AccessControl.mutable
+            access = (
+                ast.AccessControl.readonly if array_ctx.READONLY() else ast.AccessControl.mutable
+            )
             base_type = self.visit(array_ctx.scalarType())
             dimensions = (
                 self.visit(array_ctx.expression())

--- a/source/openqasm/openqasm3/printer.py
+++ b/source/openqasm/openqasm3/printer.py
@@ -487,14 +487,18 @@ class Printer(QASMVisitor[PrinterState]):
 
     def visit_ClassicalArgument(self, node: ast.ClassicalArgument, context: PrinterState) -> None:
         if node.access is not None:
-            self.stream.write("const " if node.access == ast.AccessControl.const else "mutable ")
+            self.stream.write(
+                "readonly " if node.access == ast.AccessControl.readonly else "mutable "
+            )
         self.visit(node.type, context)
         self.stream.write(" ")
         self.visit(node.name, context)
 
     def visit_ExternArgument(self, node: ast.ExternArgument, context: PrinterState) -> None:
         if node.access is not None:
-            self.stream.write("const " if node.access == ast.AccessControl.const else "mutable ")
+            self.stream.write(
+                "readonly " if node.access == ast.AccessControl.readonly else "mutable "
+            )
         self.visit(node.type, context)
 
     @_maybe_annotated

--- a/source/openqasm/tests/test_printer.py
+++ b/source/openqasm/tests/test_printer.py
@@ -141,7 +141,7 @@ def f(int[SIZE] a) {
 }
 def f(qubit q1, qubit[SIZE] q2) {
 }
-def f(const array[int[32], 2] a, mutable array[uint, #dim=2] b) {
+def f(readonly array[int[32], 2] a, mutable array[uint, #dim=2] b) {
 }
 """.strip()
         output = openqasm3.dumps(openqasm3.parse(input_), indent="  ").strip()

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -1039,8 +1039,8 @@ def test_subroutine_signatures():
     def a(int[8] b) {}
     def a(complex[float[32]] b, qubit c) -> int[32] {}
     def a(bit[5] b, qubit[2] c) -> complex[float[64]] {}
-    def a(qubit b, const array[uint[8], 2, 3] c) {}
-    def a(mutable array[uint[8], #dim=5] b, const array[uint[8], 5] c) {}
+    def a(qubit b, readonly array[uint[8], 2, 3] c) {}
+    def a(mutable array[uint[8], #dim=5] b, readonly array[uint[8], 5] c) {}
     """.strip()
     program = parse(p)
     a, b, c = Identifier(name="a"), Identifier(name="b"), Identifier(name="c")
@@ -1087,7 +1087,7 @@ def test_subroutine_signatures():
                             dimensions=[IntegerLiteral(2), IntegerLiteral(3)],
                         ),
                         name=c,
-                        access=AccessControl.const,
+                        access=AccessControl.readonly,
                     ),
                 ],
                 return_type=None,
@@ -1115,7 +1115,7 @@ def test_subroutine_signatures():
                             dimensions=[IntegerLiteral(5)],
                         ),
                         name=c,
-                        access=AccessControl.const,
+                        access=AccessControl.readonly,
                     ),
                 ],
                 return_type=None,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Formalise rules for compile-time `const` expressions, and change array access
modifier to `readonly` from `const`.

These updates are generally expected to be consistent with what
implementations already do, but formalised completely into the language
specification.

This also formalises the idea of the expressions that are guaranteed to
be evaluated at compile-time, and thus which expressions are guaranteed
to be valid to use as widths in type declarations, and in qubit
dereferencing.  This change does not attempt to solve the issue of the
allowed "dynamic dereferencing" of qubits, but fully defines the
problem: a reference to a qubit is dynamic if the type of the indexing
value is not `const`.  Implementations of OpenQASM 3.0 are permitted to
treat this as an error.

This change also fleshes out the section on built-in "scientific
calculator" functions on constant expressions, adding specific rules for
how the particular overload is chosen.

The change of the array access modifier in subroutines is to avoid unnecessary,
misleading conflict with the type modifier `const` that generally means
"compile-time constant".



### Details and comments

This is in draft for initial comments from the types-and-casting WG first (since this is my attempt to formalise in writing what we've discussed and agreed upon).  The majority of the `const` expression rules here should be largely consistent with what current implementations are already doing in terms of compile-time constant folding, but formalises the rules, to give users a well-defined base point.

This PR _does not include_ two potential extensions to this scheme that have also been discussed:
- `const` type for `for`-loop variables, requiring the loop to be unrolled at compile time;
- `const def` functions, for user-defined compile-time macros.

I will write up the first of these (`for`-loop unrolling if the loop variable has `const` type) in a separate PR on top of this as a potential discussion topic.  That may well not be suitable for the 3.0 release, however.

We have no pressing need for user-defined compile-time macros in the 3.0 spec.