### PR TITLE
Use custom OpenQASM 3 lexer to highlight code examples

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-sphinx
+Sphinx>=4.0
 sphinxcontrib-bibtex
+openqasm_pygments~=0.1.0
 pylint
 reno

--- a/source/conf.py
+++ b/source/conf.py
@@ -45,6 +45,12 @@ exclude_patterns: List[str] = [
     "openqasm/docs",
 ]
 
+# Sets the default code-highlighting language.  `.. code-block::` directives
+# that are not OQ3 should specify the language manually.  The value is
+# interpreted as a Pygments lexer alias; this needs the dependency
+# `openqasm_pygments`.
+highlight_language = "qasm3"
+
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -28,7 +28,7 @@ right-hand-side (RHS) of the assignment operator must be of the same
 type. For real-time values assignment is by copy of the RHS value to the
 assigned variable on the LHS.
 
-.. code-block:: c
+.. code-block::
 
    int[32] a;
    int[32] b = 10; // Combined declaration and assignment
@@ -49,7 +49,7 @@ shift operators shift bits off the end. They also support bitwise negation ``~``
 ``popcount`` [1]_, and left and right circular shift, ``rotl`` and ``rotr``,
 respectively.
 
-.. code-block:: c
+.. code-block::
 
    bit[8] a = "10001111";
    bit[8] b = "01110000";
@@ -79,7 +79,7 @@ be compared (:math:`>`, :math:`>=`, :math:`<`, :math:`<=`, :math:`==`,
 operators: and ``&&``, or ``||``, not ``!``. The keyword ``in`` tests if an integer belongs to
 an index set, for example ``i in {0,3}`` returns ``true`` if i equals 0 or 3 and ``false`` otherwise.
 
-.. code-block:: c
+.. code-block::
 
    bool a = false;
    int[32] b = 1;
@@ -109,7 +109,7 @@ Integers
 
 Integer types support addition ``+``, subtraction ``-``, multiplication ``*``, integer division [2]_ ``/``, modulo ``%``, and power ``**``, as well as the corresponding assignments ``+=``, ``-=``, ``*=``, ``/=``, ``%=``, and ``**=``.
 
-.. code-block:: c
+.. code-block::
 
    int[32] a = 2;
    int[32] b = 3;
@@ -174,7 +174,7 @@ Floating-point numbers
 Floating-point numbers support addition, subtraction, multiplication, division,
 and power and the corresponding assignment operators.
 
-.. code-block:: c
+.. code-block::
 
    angle[20] a = pi / 2;
    angle[20] b = pi;
@@ -200,7 +200,7 @@ These operations use the floating-point semantics of the underlying component
 floating-point types, including their ``NaN`` propagation, and
 hardware-dependent rounding mode and subnormal handling.
 
-.. code-block:: c
+.. code-block::
 
    complex[float[64]] a = 10.0 + 5.0im;
    complex[float[64]] b = -2.0 - 7.0im;
@@ -259,7 +259,7 @@ may optionally be followed by ``else <false-body>``.  Both ``true-body`` and
 ``false-body`` can be a single statement terminated by a semicolon, or a program
 block of several statements ``{ stmt1; stmt2; }``.
 
-.. code-block:: c
+.. code-block::
 
    bool target = false;
    qubit a;
@@ -317,7 +317,7 @@ not affect the next value that the loop variable will take.
 The scope of the loop variable is limited to the body of the loop.  It is not
 accessible after the loop.
 
-.. code-block:: c
+.. code-block::
 
    int[32] b = 0;
    // loop over a discrete set of values
@@ -358,7 +358,7 @@ within the while loop body.  The ``body`` can be either a single statement
 terminated by a semicolon, or a program block in curly braces ``{}`` of several
 statements:
 
-.. code-block:: c
+.. code-block::
 
    qubit q;
    bit result;
@@ -386,7 +386,7 @@ is the evaluation of the loop condition.  In a ``for`` loop, this is the
 assignment of the next value of the loop variable, or the end of the loop if the
 current value is the last in the set.
 
-.. code-block:: c
+.. code-block::
 
    int[32] i = 0;
 
@@ -410,7 +410,7 @@ current value is the last in the set.
 It is an error to have a ``break;`` or ``continue;`` statement outside a loop,
 such as at the top level of the main circuit or of a subroutine.
 
-.. code-block:: c
+.. code-block::
    
    OPENQASM 3.0;
 

--- a/source/language/comments.rst
+++ b/source/language/comments.rst
@@ -3,13 +3,13 @@ Comments
 
 Comments begin with a pair of forward slashes ``//`` and end with a new line:
 
-.. code-block:: c
+.. code-block::
 
    // A comment line
 
 A comment block begins with ``/*`` and ends with ``*/``:
 
-.. code-block:: c
+.. code-block::
 
    /*
    A comment block
@@ -36,7 +36,7 @@ Included files
 The statement ``include "filename";`` continues parsing ``filename`` as if the
 contents of the file were inserted at the location of the ``include`` statement.
 
-.. code-block:: c
+.. code-block::
 
    // First non-comment is a version string
    OPENQASM 3.0;

--- a/source/language/delays.rst
+++ b/source/language/delays.rst
@@ -44,7 +44,7 @@ type of referential timing.
 
 Below are some examples of values of type ``duration``.
 
-.. code-block:: c
+.. code-block::
 
        // fixed duration, in standard units
        duration a = 300ns;
@@ -82,7 +82,7 @@ For example, in order to ensure a sequence of gates between two barriers
 will be left-aligned (:numref:`fig_alignment`\a),
 whatever their actual durations may be, we can do the following:
 
-.. code-block:: c
+.. code-block::
 
        qubit[5] q;
        barrier q;
@@ -100,7 +100,7 @@ whatever their actual durations may be, we can do the following:
 We can further control the exact alignment by giving relative weights to
 the stretchy delays (:numref:`fig_alignment`\b):
 
-.. code-block:: c
+.. code-block::
 
        qubit[5] q;
        stretch g;
@@ -134,7 +134,7 @@ passing a negative duration to a ``gate[duration]`` or ``box[duration]`` express
 All operations on durations happen at compile time since ultimately all
 durations, including stretches, will be resolved to constants.
 
-.. code-block:: c
+.. code-block::
 
        duration a = 300ns;
        duration b = durationof({x $0;});
@@ -214,7 +214,7 @@ are explicitly defined as such. They can be called by passing a valid ``duration
 their duration. Consider for example a rotation called ``rotary`` that is applied
 for the entire duration of some other gate.
 
-.. code-block:: c
+.. code-block::
 
        const amp = /* number */;
        stretch a;
@@ -226,7 +226,7 @@ A multi-qubit ``delay`` instruction is *not* equivalent to multiple single-qubit
 point on the qubits, where the delay begins from the latest non-idle
 time across all qubits, and ends simultaneously across all qubits.
 
-.. code-block:: c
+.. code-block::
 
        cx q[0], q[1];
        cx q[2], q[3];
@@ -242,7 +242,7 @@ where the \*centers\* of pulses are equidistant from each other. We
 specify correct durations for the delays by using backtracking operations
 to properly take into account the finite duration of each gate.
 
-.. code-block:: c
+.. code-block::
 
    stretch a;
    stretch b;
@@ -280,7 +280,7 @@ part of an optimization is forbidden. The compiler can also infer a description 
 operation which a ``box`` definition is meant to realise, allowing it to re-order gates around
 the box. For example, consider a dynamical decoupling sequence inserted in a part of the circuit:
 
-.. code-block:: c
+.. code-block::
 
     rx(2*π/12) q;
     box {
@@ -295,7 +295,7 @@ the box. For example, consider a dynamical decoupling sequence inserted in a par
 By boxing the sequence, we create a box that implements the identity. The compiler is now free
 to commute a gate past the box by knowing the unitary implemented by the box:
 
-.. code-block:: c
+.. code-block::
 
     rx(5*π/12) q;
     box {
@@ -318,7 +318,7 @@ of the parameterized gates ``mygate1(a, b), mygate2(a, b)`` depend on values of 
 ``a`` and ``b`` in a complex way, but an offline calculation has shown that the total will never
 require more than 150ns for all valid combinations:
 
-.. code-block:: c
+.. code-block::
 
     // some complicated circuit that gives runtime values to a, b
     box [150ns] {
@@ -336,7 +336,7 @@ The ``barrier`` instruction of OpenQASM 2 prevents commutation and gate reorderi
 on a set of qubits across its source line. The syntax is ``barrier qregs|qubits;`` and can be seen
 in the following example
 
-.. code-block:: c
+.. code-block::
 
    cx r[0], r[1];
    h q[0];

--- a/source/language/directives.rst
+++ b/source/language/directives.rst
@@ -28,16 +28,14 @@ this specification, such as adding directives to a simulator.
 specification does not define any pragmas. Please consult your tool's
 documentation for supported pragmas.
 
-.. code-block:: c
-   :force:
+.. code-block::
 
    pragma simulator noise model "qpu1.noise"
 
 Pragmas can also be used to specify system-level information or assertions for
 the entire circuit.
 
-.. code-block:: c
-   :force:
+.. code-block::
 
    OPENQASM 3.0;
 
@@ -64,8 +62,7 @@ interaction between annotations are prescribed by this specification.
 specification does not define any annotations. Please consult your tool's
 documentation for supported annotations.
 
-.. code-block:: c
-   :force:
+.. code-block::
 
    // Manage port binding on a physical device
    @bind IOPORT[3:2]
@@ -129,8 +126,7 @@ file, which only has to be compiled once, amortizing the cost of compilation
 across many runs. For an example, we may consider a parameterized circuit which
 performs a measurement in a basis given by an input parameter:
 
-.. code-block:: c
-   :force:
+.. code-block::
 
    input int basis; // 0 = X basis, 1 = Y basis, 2 = Z basis
    output bit result;
@@ -148,7 +144,7 @@ many times using different sets of free parameters to minimize an expectation
 value. The following is an example, in which there is also more than one input
 variable:
 
-.. code-block:: c
+.. code-block::
 
    input angle[32] param1;
    input angle[32] param2;
@@ -164,7 +160,6 @@ The following Python pseudocode illustrates the differences between using and
 not using parameterized circuits in a quantum program for the case of the VQE:
 
 .. code-block:: python
-   :force:
 
    # Example without using parametric circuits:
 

--- a/source/language/gates.rst
+++ b/source/language/gates.rst
@@ -42,8 +42,7 @@ global phase. For example ``U(π/2, 0, π) q[0];``, applies a Hadamard gate to q
 New gates are associated to a unitary transformation by defining them as a sequence of built-in or
 previously defined gates. For example the ``gate`` block
 
-.. code-block:: c
-   :force:
+.. code-block::
 
    gate h q {
       U(π/2, 0, π) q;
@@ -57,8 +56,7 @@ the user and/or compiler, given information about the instructions supported by 
 Controlled gates can be constructed by adding a control modifier to an existing gate. For example,
 the NOT gate is given by ``X = U(π, 0, π)`` and the block
 
-.. code-block:: c
-   :force:
+.. code-block::
 
    gate CX a, b {
       ctrl @ U(π, 0, π) a, b;
@@ -136,8 +134,7 @@ that is applied when the control qubit is one. To capture the programmer's inten
 allows the inclusion of arbitrary global phases on circuits. The instruction ``gphase(γ);`` adds a global phase
 of :math:`e^{i\gamma}` to the scope containing the instruction. For example
 
-.. code-block:: c
-   :force:
+.. code-block::
 
    gate rz(tau) q {
      gphase(-tau/2);
@@ -175,8 +172,7 @@ transformation by a sequence of built-in gates. For example, a CPHASE
 operation is shown schematically in :numref:`fig_gate`
 corresponding OpenQASM code is
 
-.. code-block:: c
-   :force:
+.. code-block::
 
    gate cphase(θ) a, b
    {
@@ -204,7 +200,7 @@ gate set supported by a particular target.
 
 In general, new gates are defined by statements of the form
 
-.. code-block:: c
+.. code-block::
 
    // comment
    gate name(params) qargs
@@ -220,7 +216,7 @@ variable parameters, the parentheses are optional. At least one qubit
 argument is required. The arguments in ``qargs`` cannot be indexed within the body
 of the gate definition.
 
-.. code-block:: c
+.. code-block::
 
    // this is ok:
    gate g a
@@ -252,7 +248,7 @@ The gate can be applied to any combination of qubit registers *of the same size*
 
 The quantum circuit given by
 
-.. code-block:: c
+.. code-block::
 
    gate g qb0, qb1, qb2, qb3
    {
@@ -267,7 +263,7 @@ The quantum circuit given by
 
 has a second-to-last line that means
 
-.. code-block:: c
+.. code-block:: text
 
    // FIXME: insert translation of algorithmic block from TeX source.
 
@@ -297,8 +293,7 @@ gate does not use any additional scratch space and may require compilation to be
 We define a special case, the controlled *global* phase gate, as
 :math:`ctrl @ gphase(a) = U(0, 0, a)`. This is a single qubit gate.
 
-.. code-block:: c
-   :force:
+.. code-block::
 
    // Define a controlled Rz operation using the ctrl gate modifier.
    // q1 is control, q2 is target
@@ -311,8 +306,7 @@ controlled value of 0 rather than 1. Mathematically, the negative controlled-:ma
 given by :math:`N_U = I \otimes U^{1-c}`, where :math:`c` is the integer value of the control bit
 and :math:`N_U` is the negative controlled-:math:`U` gate.
 
-.. code-block:: c
-   :force:
+.. code-block::
 
    // Define a negative controlled X operation using the negctrl gate modifier.
    // q1 is control, q2 is target
@@ -334,8 +328,7 @@ where :math:`c_1`, :math:`c_2`, ..., :math:`c_n` are the integer values of the c
 :math:`C^n_U` are the n-bit controlled-:math:`U` and n-bit negative controlled-:math:`U` gates,
 respectively.
 
-.. code-block:: c
-   :force:
+.. code-block::
 
    // A reversible boolean function
    // Demonstrates use of ``ctrl(n) @`` and ``negctrl(n) @``
@@ -352,14 +345,16 @@ The modifier ``inv @`` replaces its gate argument :math:`U` with its inverse
 :math:`U^\dagger`. This can be computed from gate :math:`U` via the following rules
 
 - The inverse of any gate :math:`U=U_m U_{m-1} ... U_1` can be defined recursively by reversing the
-order of the gates in its definition and replacing each of those with their inverse
-:math:`U^\dagger = U_1^\dagger U_2^\dagger ... U_m^\dagger`.
-- The inverse of a controlled operation is defined by inverting the control unitary. That is,
-``inv @ ctrl @ U = ctrl @ inv @ U``.
-- The base case is given by replacing ``inv @ U(θ, ϕ, λ)`` by ``U(-θ, -λ, -ϕ)`` and
-``inv @ gphase(a)`` by ``gphase(-a)``.
+  order of the gates in its definition and replacing each of those with their inverse
+  :math:`U^\dagger = U_1^\dagger U_2^\dagger ... U_m^\dagger`.
 
-.. code-block:: c
+- The inverse of a controlled operation is defined by inverting the control unitary. That is,
+  ``inv @ ctrl @ U = ctrl @ inv @ U``.
+
+- The base case is given by replacing ``inv @ U(θ, ϕ, λ)`` by ``U(-θ, -λ, -ϕ)``
+  and ``inv @ gphase(a)`` by ``gphase(-a)``.
+
+.. code-block::
 
    // Define a negative z rotation and the inverse of a positive z rotation
    gate rzm(θ) q1 {
@@ -376,7 +371,7 @@ constant). In the case that :math:`k` is an integer, the gate can be implemented
 inefficiently) by :math:`k` repetitions of :math:`U` for :math:`k > 0` and :math:`k`
 repetitions of ``inv @ U`` for :math:`k < 0`.
 
-.. code-block:: c
+.. code-block::
 
    // define x as the square of sqrt(x) ``sx`` gate
    gate x q1 {

--- a/source/language/insts.rst
+++ b/source/language/insts.rst
@@ -11,7 +11,7 @@ The statement ``reset qubit|qubit[];`` resets a qubit or quantum register to the
 (i.e. discarding them) before replacing them with
 :math:`|0\rangle\langle 0|`. Reset is shown in :numref:`fig_prepare`.
 
-.. code-block:: c
+.. code-block::
 
    // Initialize and reset a register of 10 qubits
    qubit[10] qubits;
@@ -43,7 +43,7 @@ arguments are register-type and have the same size, the statement  ``b = measure
 broadcasts to ``b[j] = measure a[j];`` for each index ``j`` into register ``a``. Measurement is shown in
 :numref:`fig_measure`.
 
-.. code-block:: c
+.. code-block::
 
    // Initialize, flip and measure a register of 10 qubits
    qubit[10] qubits;

--- a/source/language/openpulse.rst
+++ b/source/language/openpulse.rst
@@ -75,7 +75,7 @@ to capture data. The hardware can be accessed as OpenPulse ``port``'s via ``exte
 identifier that specifies an external linkage that will be resolved at compile-time via vendor
 supplied translation units.
 
-.. code-block:: c
+.. code-block:: openpulse
 
     extern port drive_port0
 
@@ -112,7 +112,7 @@ The frame is composed of four parts:
 
 A ``frame`` from an existing calibration can also be accessed via an ``extern`` identifier
 
-.. code-block:: c
+.. code-block:: openpulse
 
     extern frame xy_frame0
 
@@ -125,7 +125,7 @@ Frame Initialization
 
 Frames can be initialized using the ``newframe`` command by providing the ``port``, ``frequency``, and ``phase`` e.g.
 
-.. code-block:: javascript
+.. code-block:: openpulse
 
   extern port drive0;
   frame driveframe0 = newframe(drive0, 5e9, 0.0); // newframe(port pr, float[size] frequency, angle[size] phase)
@@ -139,7 +139,7 @@ to raise a compile-time error when such an initialization is encountered.
 
 Note that multiple frames may address the same port e.g.
 
-.. code-block:: javascript
+.. code-block:: openpulse
 
   extern port measure_port;
   frame measure_frame_0 = newframe(measure_port, 5e9, 0.0);
@@ -161,7 +161,7 @@ by using ``set`` and ``shift`` instructions and read using a ``get`` instruction
 the `set_phase` and `shift_phase` instructions allow one to supply the frame and a value of type
 ``angle`` representing the amount by which to set/shift the phase.
 
-.. code-block:: javascript
+.. code-block:: openpulse
 
   set_phase(frame fr, angle phase);
   shift_phase(frame fr, angle phase);
@@ -169,14 +169,14 @@ the `set_phase` and `shift_phase` instructions allow one to supply the frame and
 The `get_phase` instruction allows one to supply the frame from which to retrieve the phase of
 type ``angle``.
 
-.. code-block:: javascript
+.. code-block:: openpulse
 
   get_phase(frame fr) -> angle;
 
 Analogously, the `set_frequency` and `shift_frequency` instructions allow one to supply the frame
 and a value of type ``float`` representing the amount by which to set/shift the frequency.
 
-.. code-block:: javascript
+.. code-block:: openpulse
 
   set_frequency(frame fr, float freq);
   shift_frequency(frame fr, float freq);
@@ -184,7 +184,7 @@ and a value of type ``float`` representing the amount by which to set/shift the 
 The `get_frequency` instruction allows one to supply the frame from which to retrieve the frequency
 of type ``float``.
 
-.. code-block:: javascript
+.. code-block:: openpulse
 
   get_frequency(frame fr) -> float;
 
@@ -200,9 +200,8 @@ is set to an out of bounds value, the compiler shall raise a compile-time error.
 Here's an example of manipulating the phase to calibrate an ``rz`` gate on a frame called
 ``driveframe``:
 
-.. code-block:: javascript
-
-  ...
+.. code-block:: openpulse
+   :force:
 
    // Shift phase of the "drive" frame by pi/4, to realize a virtual rz gate with angle -pi/4
    cal {
@@ -227,7 +226,7 @@ Here's an example of manipulating the phase to calibrate an ``rz`` gate on a fra
 
 Manipulating frames based on the state of other frames is also permitted:
 
-.. code-block:: javascript
+.. code-block:: openpulse
 
    angle temp1 = get_phase(frame1);
    angle temp2 = get_phase(frame2);
@@ -262,7 +261,8 @@ generators may have optimized implementations of common pulse shapes like gaussi
 Providing structured gaussian parameters instead of the materialized list of complex
 samples provides optimization opportunities that wouldn't be available otherwise.
 
-.. code-block:: javascript
+.. code-block:: openpulse
+   :force:
 
    // arbitrary complex samples
    waveform arb_waveform = [1+0im, 0+1im, 1/sqrt(2)+1/sqrt(2)im];
@@ -302,7 +302,7 @@ samples provides optimization opportunities that wouldn't be available otherwise
 We can manipulate the ``waveform`` types using the following signal processing functions to produce
 new waveforms (this list may be updated as more functionality is required).
 
-.. code-block:: javascript
+.. code-block:: openpulse
 
     // Multiply two input waveforms entry by entry to produce a new waveform
     // :math:`wf(t_i) = wf_1(t_i) \times wf_2(t_i)`
@@ -331,13 +331,14 @@ Here, the ``frame`` provides the time at which the ``waveform`` envelope is sche
 the frame's current ``time``), its carrier frequency (i.e. via the frames current ``frequency``),
 and its phase offset (i.e. via the frame's current ``phase``).
 
-.. code-block:: javascript
+.. code-block:: openpulse
 
   play(frame fr, waveform wfm)
 
 For example,
 
-.. code-block:: javascript
+.. code-block:: openpulse
+  :force:
 
   defcal play_my_pulses $0 {
     // Play a 3 sample pulse on the tx0 port
@@ -374,7 +375,7 @@ However, the following are possible parameters that might also be included:
 Again it is up to the hardware vendor to determine the parameters and write a
 extern definition at the top-level, such as:
 
-.. code-block:: javascript
+.. code-block:: openpulse
 
    // Minimum requirement
    extern capture_v0(frame output);
@@ -399,7 +400,9 @@ pushing the results into some buffer which is then accessed outside the program.
 For example, the ``capture`` instruction could return raw waveform data that is then
 discriminated using user-defined boxcar and discrimination ``extern``\s.
 
-.. code-block:: javascript
+.. code-block::
+
+    defcalgrammar "openpulse";
 
     // Use a boxcar function to generate IQ data from raw waveform
     extern boxcar(waveform input) -> complex[float[64]];
@@ -456,9 +459,9 @@ As briefly discussed in the :ref:`Frame Initialization` section, a ``frame`` ini
 would be absolute 0. Meanwhile, a ``defcal``\s start time is determined by when it is scheduled
 (see :ref:`Timing` section for more details) e.g.
 
-.. code-block:: javascript
+.. code-block::
 
-  ...
+  defcalgrammar "openpulse";
 
   cal {
     extern port d0;
@@ -496,9 +499,7 @@ Delay
 When a ``delay`` instruction is issued for a list of ``frame``\s, the ``frame`` clocks advance
 by the requested duration.
 
-.. code-block:: javascript
-
-  ...
+.. code-block:: openpulse
 
   // driveframe advances by 13ns
   delay[13ns] driveframe;
@@ -512,9 +513,7 @@ Play and Capture
 When a ``play`` or ``capture`` instruction is issued, the ``frame`` clock advances
 by the duration of the associated ``waveform`` argument.
 
-.. code-block:: javascript
-
-  ...
+.. code-block:: openpulse
 
   cal {
     extern port d0;
@@ -534,7 +533,9 @@ Barrier
 When a ``barrier`` instruction is issued for a list of ``frame``\s, the ``frame`` clocks are
 aligned to the latest time of the all ``frame``\s listed.
 
-.. code-block:: javascript
+.. code-block::
+
+  defcalgrammar "openpulse";
 
   cal {
     extern port d0;
@@ -555,12 +556,14 @@ aligned to the latest time of the all ``frame``\s listed.
 
 Moreover, ``defcal`` blocks have an implicit ``barrier`` on every frame enters the block e.g.
 
-.. code-block:: javascript
+.. code-block::
+
+  defcalgrammar "openpulse";
 
   cal {
     extern port tx0;
     extern port tx1;
-    waveform p = ...; // some 100ns waveform
+    waveform p = /* ... some 100ns waveform ... */;
     frame driveframe1 = newframe(tx0, 5.0e9, 0);
     frame driveframe2 = newframe(tx1, 6.0e9, 0);
   }
@@ -589,11 +592,13 @@ manipulated throughout a program via ``set_phase`` and ``shift_phase`` instructi
 the phase is implicitly manipulated when the time of the frame is advanced using a ``delay``,
 ``play``, or ``capture`` instruction e.g.
 
-.. code-block:: javascript
+.. code-block::
+
+  defcalgrammar "openpulse";
 
   cal {
     extern port tx0;
-    waveform p = ...; // some 100ns waveform
+    waveform p = /* ... some 100ns waveform ... */;
 
     // Frame initialized with accrued phase of 0
     frame driveframe0 = newframe(tx0, 5.0e9, 0);
@@ -632,9 +637,9 @@ Collisions
 If a frame is scheduled or referenced simultaneously in two ``defcal`` or ``cal`` blocks, it is
 considered a compile-time error e.g.
 
-.. code-block:: javascript
+.. code-block::
 
-  ...
+  defcalgrammar "openpulse";
 
   defcal single_qubit_gate $0 {
     play(driveframe1, wf);
@@ -643,8 +648,6 @@ considered a compile-time error e.g.
   defcal single_qubit_gate $1 {
     play(driveframe1, wf);
   }
-
-  ...
 
   // Compile-time error when requesting parallel usage of the same frame
   single_qubit_gate $0 $1;
@@ -668,7 +671,9 @@ the program.
 
 Here we want to sweep the frequency of a long pulse that saturates the qubit transition.
 
-.. code-block:: javascript
+.. code-block::
+
+  defcalgrammar "openpulse";
 
   // sweep parameters would be programmed in by some higher level bindings
   const float frequency_start = 4.5e9;
@@ -700,7 +705,9 @@ Here we want to sweep the frequency of a long pulse that saturates the qubit tra
 
 Here we want to sweep the time of the pulse and observe coherent Rabi flopping dynamics.
 
-.. code-block:: javascript
+.. code-block::
+
+  defcalgrammar "openpulse";
 
   const duration pulse_length_start = 20dt;
   const duration pulse_length_step = 1dt;
@@ -722,7 +729,9 @@ Cross-resonance gate
 ~~~~~~~~~~~~~~~~~~~~
 
 
-.. code-block:: javascript
+.. code-block::
+
+  defcalgrammar "openpulse";
 
   cal {
      // Access globally (or externally) defined ports
@@ -751,7 +760,10 @@ Cross-resonance gate
 Geometric gate
 ~~~~~~~~~~~~~~
 
-.. code-block:: javascript
+.. code-block::
+  :force:
+
+  defcalgrammar "openpulse";
 
   cal {
       extern port dq;
@@ -766,8 +778,8 @@ Geometric gate
 
       // Assume we have calibrated 0->1 pi pulses and 1->2 pi pulse
       // envelopes (no sideband)
-      waveform X_01 = {...};
-      waveform X_12 = {...};
+      waveform X_01 = { ... };
+      waveform X_12 = { ... };
       float[32] a = sin(theta/2);
       float[32] b = sqrt(1-a**2);
 
@@ -791,7 +803,10 @@ sideband).
 
 The program aims to perform a Hahn echo sequence on q1, and a Ramsey sequence on q2 and q3.
 
-.. code-block:: javascript
+.. code-block::
+  :force:
+
+  defcalgrammar "openpulse";
 
   // Raman transition detuning Δ from the  5S1/2 to 5P1/2 transition
   const float Δ = ...;
@@ -832,7 +847,7 @@ The program aims to perform a Hahn echo sequence on q1, and a Ramsey sequence on
     frame q3_frame = newframe(aod_port, qubit_freq, 0)
 
     // Generic gaussian envelope
-    waveform π_half_sig = gaussian(..., π_half_time, ...);
+    waveform π_half_sig = gaussian(1.0, π_half_time, 100dt);
 
     // Waveforms ultimately supplied to the AODs. We mix our general Gaussian pulse with a sine wave to
     // put a sideband on the outgoing pulse. This helps us target the qubit position while maintainig the
@@ -897,7 +912,10 @@ In this example, we want to perform readout and capture of a pair of qubits, but
 single physical transmission and capture port. The example is for just two qubits, but works the same for
 many (just adding more frames, waveforms, plays, and captures).
 
-.. code-block:: javascript
+.. code-block::
+  :force:
+
+  defcalgrammar "openpulse";
 
   const duration electrical_delay = ...;
   const float q0_ro_freq = ...;

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -22,7 +22,7 @@ The entry point to such gate and measurement definitions is the ``defcal`` keywo
 analogous to the ``gate`` keyword, but where the ``defcal`` body specifies a pulse-level
 instruction sequence on *physical* qubits, e.g.
 
-.. code-block:: c
+.. code-block::
 
    defcal rz(angle[20] theta) $0 { ... }
    defcal measure $0 -> bit { ... }
@@ -48,7 +48,7 @@ causes that calibration definition to be valid for all physical qubits.
 This is most likely to be useful for gates that are implemented virtually.
 For instance, to define an equivalent `rz` calibration on qubits 0 and 1, we could write
 
-.. code-block:: c
+.. code-block::
 
    defcal rz(angle[20] theta) q { ... }
    // we've defined ``rz`` on arbitrary physical qubits, so we can do:
@@ -60,7 +60,7 @@ As a consequence of the need for specialization of operations on
 particular qubits, the same symbol may be defined multiple
 times, e.g.
 
-.. code-block:: c
+.. code-block::
 
    defcal h $0 { ... }
    defcal h $1 { ... }
@@ -69,7 +69,7 @@ and so forth. Some operations require further specialization on
 parameter values, so we also allow multiple declarations on the same
 physical qubits with different parameter values, e.g.
 
-.. code-block:: c
+.. code-block::
 
    defcal rx(pi) $0 { ... }
    defcal rx(pi / 2) $0 { ... }
@@ -90,7 +90,7 @@ Users specify the grammar used inside ``defcal`` blocks with a
 ``defcalgrammar "name"`` declaration. One such grammar is a
 `textual representation of OpenPulse <openpulse.html>`_ specified by:
 
-.. code-block:: c
+.. code-block::
 
    defcalgrammar "openpulse";
 
@@ -118,7 +118,7 @@ that may observe that scope as defined by the calibration grammar. Values may no
 In practice, calibration grammars such as OpenPulse may apply
 a global scope to all identifiers in order to declare values shared across all ``defcal`` calls thereby linking them together.
 
-.. code-block:: c
+.. code-block::
 
    OPENQASM 3;
    defcalgrammar "openpulse";
@@ -158,7 +158,7 @@ For example,  consider the case of a ``reset`` gate. The ``defcal`` for a
 ``reset`` gate can be composed of a single if statement, provided each branch
 of the if statement has definite and equivalent duration.
 
-.. code-block:: c
+.. code-block::
 
    defcal reset $0 {
       bit res = // measure qubit $0
@@ -188,7 +188,7 @@ cross-resonance device using a ``backend.inc`` include file.
 The name ``backend.inc`` is arbitrary - it's just a file to be included using the
 existing ``include`` mechanism.
 
-.. code-block:: c
+.. code-block::
 
    // backend.inc for openpulse two-qubit device
 
@@ -246,7 +246,7 @@ existing ``include`` mechanism.
 
 The user would then include the ``backend.inc`` in their own program and use them as demonstrated below
 
-.. code-block:: c
+.. code-block::
 
    OPENQASM 3.0;
 

--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -1,9 +1,9 @@
 Subroutines
 ===========
 
-Subroutines are declared using the statement
+Subroutines are declared using the statement::
 
-    ``def name(parameters) -> output_type { body }``
+    def name(parameters) -> output_type { body }
 
 Subroutines and their named arguments must be named according to the rules for
 identifiers (See :ref:`identifiers`).
@@ -23,20 +23,22 @@ Qubit declarations are not allowed within subroutines as those declarations are 
 A subroutine is invoked with the syntax ``name(parameters)`` and may be assigned
 to an ``output`` as needed via an assignment operator (``=``, ``+=``, etc).
 
-Using subroutines, we can define an X-basis measurement with the program
+Using subroutines, we can define an X-basis measurement with the program::
 
-    ``def xmeasure(qubit q) -> bit { h q; return measure q; }``
+    def xmeasure(qubit q) -> bit { h q; return measure q; }
 
 We can also define more general classes of single-qubit measurements
-as
+as::
 
-    ``def pmeasure(angle[32] theta, qubit q) -> bit {rz(theta) q; h q; return measure q;}``
+    def pmeasure(angle[32] theta, qubit q) -> bit {
+      rz(theta) q;
+      h q;
+      return measure q;
+   }
 
 The type declarations are necessary if we want to mix qubit and
 register arguments. For example, we might define a parity check
-subroutine that takes qubits and registers
-
-.. code-block:: c
+subroutine that takes qubits and registers::
 
    def xcheck(qubit[4] d, qubit a) -> bit {
      reset a;
@@ -46,9 +48,7 @@ subroutine that takes qubits and registers
 
 Naturally we can also use subroutines to define purely classical
 operations, such as methods we can implement using low-level classical
-instructions, like
-
-.. code-block:: c
+instructions, like::
 
    const n = /* some size, known at compile time */;
    def parity(bit[n] cin) -> bit {
@@ -60,9 +60,7 @@ instructions, like
    }
 
 We can make some measurements and call this subroutine on the results as
-follows
-
-.. code-block:: c
+follows::
 
    qubit q;
    qubit r;
@@ -73,9 +71,7 @@ follows
 
 We require that we know the signature at compile time, as we do in this
 example. We could also just as easily have used an extern function for
-this
-
-.. code-block:: c
+this::
 
    const n = /* size of c + size of c2 */;
    extern parity(bit[n]) -> bit;
@@ -103,13 +99,13 @@ array to a subroutine is forbidden. However, the compiler will not always be
 able to resolve when this happens, and if it does, then no guarantees are made
 about the order that updates are made in.
 
-.. code-block:: c
+.. code-block::
 
-   def specified_sub(const array[int[8], 2, 10] arr_arg) {...}
-   def arr_subroutine(const array[int[8], #dim = 1] arr_arg) {...}
+   def specified_sub(const array[int[8], 2, 10] arr_arg) { /* ... */ }
+   def arr_subroutine(const array[int[8], #dim = 1] arr_arg) { /* ... */ }
    def mut_subroutine(mutable array[int[8], #dim = 1] arr_arg) {
      arr_arg[2] = 10; // allowed
-     ...
+     // ...
    }
    array[int[8], 5] aa;
    array[int[8], 3, 5] bb;
@@ -133,7 +129,7 @@ then it defaults to ``0``, *i.e.* ``sizeof(arr) == sizeof(arr, 0)``.
 requested dimension of the array argument. The array argument can be
 subscripted, meaning that ``sizeof(arr[0], 0) == sizeof(arr, 1)``.
 
-.. code-block:: c
+.. code-block::
 
    def arr_subroutine(const array[int[8], #dim = 2] twoD_arg) {
      uint[32] firstDim  = sizeof(twoD_arg, 0);
@@ -144,5 +140,5 @@ subscripted, meaning that ``sizeof(arr[0], 0) == sizeof(arr, 1)``.
          sum += int[32](twoD_arg[ii][jj]);
        }
      }
-     ...
+     // ...
    }

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -30,7 +30,7 @@ Declaration and initialization must be done one variable at a time for both quan
 types. Comma seperated declaration/initialization (``int x, y, z``) is NOT allowed for any type. For
 example, to declare a set of qubits one must do
 
-.. code-block:: c
+.. code-block::
 
    qubit q0;
    qubit q1;
@@ -38,7 +38,7 @@ example, to declare a set of qubits one must do
 
 and to declare a set of classical variables
 
-.. code-block:: c
+.. code-block::
 
    int[32] a;
    float[32] b = 5.5;
@@ -92,8 +92,7 @@ references given by ``$0``, ``$1``, ..., ``$n-1``. These qubit types are
 used in lower parts of the compilation stack when emitting physical
 circuits. Physical qubits must not be declared and they are, as all the qubits, global variables.
 
-.. code-block:: c
-   :force:
+.. code-block::
 
    // Declare a qubit
    qubit gamma;
@@ -126,7 +125,7 @@ register. It is interpreted to assign each bit of the register to
 corresponding value 0 or 1 in the string, where the least-significant
 bit is on the right.
 
-.. code-block:: c
+.. code-block::
 
    // Declare a register of 20 bits
    bit[20] bit_array;
@@ -152,7 +151,7 @@ conversion will be done assuming little-endian bit ordering. The example
 below demonstrates how to declare, assign and cast integer types amongst
 one another.
 
-.. code-block:: c
+.. code-block::
 
    // Declare a 32-bit unsigned integer
    uint[32] my_uint = 10;
@@ -174,8 +173,7 @@ unspecified size.  The resulting precision is then set by the particular target
 architecture, and the unspecified-width type is different to all specified-width
 types for the purposes of casting.
 
-.. code-block:: c
-   :force:
+.. code-block::
 
    // Declare a single-precision 32-bit float
    float[32] my_float = π;
@@ -297,7 +295,7 @@ There is a Boolean type ``bool name;`` that takes values ``true`` or ``false``. 
 can be converted from a classical ``bit`` type to a Boolean using ``bool(c)``, where 1 will
 be true and 0 will be false.
 
-.. code-block:: c
+.. code-block::
 
    bit my_bit = 0;
    bool my_bool;
@@ -327,8 +325,7 @@ A standard set of built-in constants which are included in the default
 namespace are listed in table `1 <#tab:real-constants>`__. These constants
 are all of type ``float[64]``.
 
-.. code-block:: c
-   :force:
+.. code-block::
 
    // Declare a constant
    const int my_const = 1234;
@@ -425,7 +422,7 @@ binary number, as denoted by a leading ``0x/0X``, ``0o``, or ``0b/0B`` prefix.
 Non-consecutive underscores ``_`` may be inserted between the first and last
 digit of the literal to improve readability for large values.
 
-.. code-block:: c
+.. code-block::
 
    int i1 = 1; // decimal
    int i2 = 0xff; // hex
@@ -443,7 +440,7 @@ Float literals contain either
 In addition, scientific notation can be used with a signed or unsigned integer
 exponent.
 
-.. code-block:: c
+.. code-block::
 
    float f1 = 1.0;
    float f2 = .1; // leading dot
@@ -458,7 +455,7 @@ Bit string literals are denoted by double quotes ``"`` surrounding a number of
 zero and one digits, and may include non-consecutive underscores to improve
 readability for large strings.
 
-.. code-block:: c
+.. code-block::
 
    bit[8] b1 = "00010001";
    bit[8] b2 = "0001_0001"; // underscore for readability
@@ -467,7 +464,7 @@ Timing literals are float or integer literals with a unit of time.
 ``ns, μs, us, ms, and s`` are used for SI time units. ``dt`` is a
 backend-dependent unit equivalent to one waveform sample.
 
-.. code-block:: c
+.. code-block::
 
    duration one_second = 1000ms;
    duration thousand_cycles = 1000dt;
@@ -480,7 +477,7 @@ Arrays
 Statically-sized arrays of values can be created and initialized, and individual elements
 can be accessed, using the following general syntax:
 
-.. code-block:: c
+.. code-block::
 
    array[int[32], 5] myArray = {0, 1, 2, 3, 4};
    array[float[32], 3, 2] multiDim = {{1.1, 1.2}, {2.1, 2.2}, {3.1, 3.2}};
@@ -516,7 +513,7 @@ with the left-hand side of the assignment operating as a reference, thereby
 updating the values inside the original array. For multi-dimensional arrays,
 the shape and type of the assigned value must match that of the reference.
 
-.. code-block:: c
+.. code-block::
 
    array[int[8], 3] aa;
    array[int[8], 4, 3] bb;
@@ -540,7 +537,7 @@ Durations can be assigned with expressions including timing literals.
 ``durationof()`` is an intrinsic function used to reference the
 duration of a calibrated gate.
 
-.. code-block:: c
+.. code-block::
 
    duration one_second = 1000ms;
    duration thousand_cycles = 1000dt;
@@ -566,7 +563,7 @@ Aliasing
 The ``let`` keyword allows quantum bits and registers to be referred to by
 another name as long as the alias is in scope.
 
-.. code-block:: c
+.. code-block::
 
   qubit[5] q;
   // myreg[0] refers to the qubit q[1]
@@ -605,7 +602,7 @@ empty set. If :math:`c` is not given, it is assumed to be one, and
 :math:`c` cannot be zero. Note the index sets can be defined by
 variables whose values may only be known at run time.
 
-.. code-block:: c
+.. code-block::
 
    qubit[2] one;
    qubit[10] two;
@@ -633,7 +630,7 @@ A subset of classical values (int, uint, and angle) may be accessed at the bit
 level using index sets similar to register slicing. The bit slicing operation
 always returns a bit array of size equal to the size of the index set.
 
-.. code-block:: c
+.. code-block::
 
    int[32] myInt = 15; // 0xF or 0b1111
    bit[1] lastBit = myInt[0]; // 1
@@ -652,7 +649,7 @@ subscript operator to reduce confusion. With this convention nearly all
 instances of multiple subscripts ``[][]`` will be bit-level accesses of array
 elements.
 
-.. code-block:: c
+.. code-block::
 
    array[int[32], 5] intArr = {0, 1, 2, 3, 4};
    // Access bit 0 of element 0 of intArr and set it to 1
@@ -674,7 +671,7 @@ operator is forbidden to be used directly in the argument list of a subroutine
 or extern call. If a concatenated array is to be passed to a subroutine then it
 should be explicitly declared and assigned the concatenation.
 
-.. code-block:: c
+.. code-block::
 
    array[int[8], 2] first = {0, 1};
    array[int[8], 3] second = {2, 3, 4};
@@ -703,7 +700,7 @@ multi-dimensional arrays.
 For sliced assignments, as with non-sliced assignments, the shapes and types of
 the slices must match.
 
-.. code-block:: c
+.. code-block::
 
    int[8] scalar;
    array[int[8], 2] oneD;
@@ -882,7 +879,7 @@ Casting from or to duration values is not allowed, however, operations on
 durations that produce values of different types is allowed. For example,
 dividing a duration by a duration produces a machine-precision ``float``.
 
-.. code-block:: c
+.. code-block::
 
    duration one_ns = 1ns;
    duration a = 500ns;


### PR DESCRIPTION
### Summary

This uses the new `openqasm-pygments` package that we just published on PyPI ([GitHub repo](https://github.com/openqasm/openqasm-pygments), [PyPI package](https://pypi.org/project/openqasm-pygments)) to do the syntax highlighting with the documentation build.  The warnings from Sphinx when I ran this turned up a couple of places where our examples aren't 100% perfect, but the highlighting is much much better now.

### Details

The OpenPulse pages have some instances where invalid OpenPulse
constructs (such as `...`) are used.  The lexer emits errors for these
(since they're not technically valid), so they require the `:force:`
directive in the code block to highlight correctly.

This puts `defcalgrammar "openpulse";` statements on long examples that
are embedded in OpenQASM itself - this makes the `qasm3` lexer swap into
the correct mode, while maintaining all the correct OpenQASM 3
highlighting as well.

Fix #369.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->


