### PR TITLE
Drop dollar sign from pulse wildcard identifier

### DIFF
--- a/examples/defcal.qasm
+++ b/examples/defcal.qasm
@@ -8,8 +8,8 @@ defcal x $1 {
   play drive($1), gaussian(...);
 }
 
-defcal rz(angle[20]:theta) $q {
-  shift_phase drive($q), -theta;
+defcal rz(angle[20]:theta) q {
+  shift_phase drive(q), -theta;
 }
 
 defcal measure $0 -> bit {

--- a/examples/pong.qasm
+++ b/examples/pong.qasm
@@ -5,19 +5,19 @@
  */
 defcalgrammar "openpulse";
 
-defcal pong(angle[32] amp, duration dur) $q {
+defcal pong(angle[32] amp, duration dur) q {
     play d0, gaussian(amp, dur)
 }
 
-defcal pong_cx(angle[32] amp) $q0, $q1, $q2 {
-    barrier $q0, $q1, $q2;
-    cross-res(pi/4) $q0, $q1
-    x(pi) $q0;  // this is a defcal
-    cross-res(-pi/4) $q0, $q1;
-    glue[1]-pong(amp) $q1;
-    glue[2]-pong(-amp) $q1;
-    glue[1]-pong(amp) $q1;
-    barrier $q0, $q1, $q2;
+defcal pong_cx(angle[32] amp) q0, q1, q2 {
+    barrier q0, q1, q2;
+    cross-res(pi/4) q0, q1
+    x(pi) q0;  // this is a defcal
+    cross-res(-pi/4) q0, q1;
+    glue[1]-pong(amp) q1;
+    glue[2]-pong(-amp) q1;
+    glue[1]-pong(amp) q1;
+    barrier q0, q1, q2;
 }
 
 barrier $0, $1, $2;

--- a/examples/t1.qasm
+++ b/examples/t1.qasm
@@ -19,8 +19,8 @@ bit c1;
 defcalgrammar "openpulse";
 
 // define a gate calibration for an X gate on any qubit
-defcal x $q {
-   play drive($q), gaussian(100, 30, 5);
+defcal x q {
+   play drive(q), gaussian(100, 30, 5);
 }
 
 for p in [0 : points-1] {

--- a/releasenotes/notes/drop-dollar-from-pulse-wildcard-2efa545932ed7736.yaml
+++ b/releasenotes/notes/drop-dollar-from-pulse-wildcard-2efa545932ed7736.yaml
@@ -1,0 +1,9 @@
+---
+upgrade:
+  - |
+    The "wildcard" identifiers in pulse grammars are now regular OpenQASM 3
+    identifiers, without the leading dollar sign (``$``), *e.g.* what was ``$q``
+    before is now simply ``q``.  Precise hardware qubits are still referenced
+    as ``$0``, for example.  This was made for better consistency in identifiers;
+    having the dollar sign in the wildcard carried no information, since it
+    applied to any qubit already.

--- a/source/grammar/qasm3Lexer.g4
+++ b/source/grammar/qasm3Lexer.g4
@@ -133,10 +133,7 @@ fragment FirstIdCharacter: '_' | ValidUnicode | Letter;
 fragment GeneralIdCharacter: FirstIdCharacter | [0-9];
 
 Identifier: FirstIdCharacter GeneralIdCharacter*;
-// TODO: OpenPulse asks for identifiers like '$q' in the argument list of
-// 'defcal' statements, though this is not a valid identifier by the OpenQASM 3
-// specification.  For now, we allow it as a special case.
-HardwareQubit: '$' ([0-9]+ | Identifier);
+HardwareQubit: '$' [0-9]+;
 
 fragment FloatLiteralExponent: [eE] (PLUS | MINUS)? DecimalIntegerLiteral;
 FloatLiteral:

--- a/source/grammar/qasm3Parser.g4
+++ b/source/grammar/qasm3Parser.g4
@@ -107,7 +107,7 @@ expressionStatement: expression SEMICOLON;
 
 // TODO: this handling of the defcal block is incorrect, because it is not
 // constrained to consume balanced brace blocks.  This needs more attention.
-defcalStatement: DEFCAL Identifier (LPAREN argumentDefinitionList? RPAREN)? hardwareQubitList returnSignature? LBRACE .*? RBRACE;
+defcalStatement: DEFCAL Identifier (LPAREN argumentDefinitionList? RPAREN)?  defcalArgumentList returnSignature? LBRACE .*? RBRACE;
 
 
 /* End top-level statement definitions. */
@@ -204,6 +204,7 @@ designator: LBRACKET expression RBRACKET;
 
 gateOperand: indexedIdentifier | HardwareQubit;
 externArgument: scalarType | arrayReferenceType | CREG designator?;
+defcalArgument: HardwareQubit | Identifier;
 argumentDefinition:
     scalarType Identifier
     | qubitType Identifier
@@ -213,7 +214,7 @@ argumentDefinition:
 
 argumentDefinitionList: argumentDefinition (COMMA argumentDefinition)* COMMA?;
 expressionList: expression (COMMA expression)* COMMA?;
-hardwareQubitList: HardwareQubit (COMMA HardwareQubit)* COMMA?;
+defcalArgumentList: defcalArgument (COMMA defcalArgument)* COMMA?;
 identifierList: Identifier (COMMA Identifier)* COMMA?;
 gateOperandList: gateOperand (COMMA gateOperand)* COMMA?;
 externArgumentList: externArgument (COMMA externArgument)* COMMA?;

--- a/source/language/openpulse.rst
+++ b/source/language/openpulse.rst
@@ -221,7 +221,7 @@ Here's an example of manipulating the phase to calibrate an ``rz`` gate on a fra
      // and so on
    }
 
-   defcal rz(angle[20] theta) $q {
+   defcal rz(angle[20] theta) q {
      shift_phase(rz_frames[q], -theta);
    }
 
@@ -761,7 +761,7 @@ Geometric gate
       frame frame_12 = newframe(dq, fq_01 + anharm, 0);
   }
 
-  defcal geo_gate(angle[32] theta) $q {
+  defcal geo_gate(angle[32] theta) q {
       // theta: rotation angle (about z-axis) on Bloch sphere
 
       // Assume we have calibrated 0->1 pi pulses and 1->2 pi pulse

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -26,7 +26,7 @@ instruction sequence on *physical* qubits, e.g.
 
    defcal rz(angle[20] theta) $0 { ... }
    defcal measure $0 -> bit { ... }
-   defcal measure_iq $q -> complex[32] { ... }
+   defcal measure_iq q -> complex[32] { ... }
 
 We distinguish gate and measurement definitions by the presence of a
 return value type in the latter case, analogous to the subroutine syntax
@@ -43,12 +43,14 @@ QASM achieves this by prefixing qubit references with ``$`` to indicate
 a specific qubit on the device, e.g. ``$2`` would refer to physical
 qubit 2.
 
-One can define a `defcal` using an arbitrary `$` identifier, provided that gate is called using physical
-qubits. For instance, to define an equivalent `rz` calibration on qubits 0 and 1, we could write
+One can define a `defcal` using a regular identifier for a qubit, which
+causes that calibration definition to be valid for all physical qubits.
+This is most likely to be useful for gates that are implemented virtually.
+For instance, to define an equivalent `rz` calibration on qubits 0 and 1, we could write
 
 .. code-block:: c
 
-   defcal rz(angle[20] theta) $q { ... }
+   defcal rz(angle[20] theta) q { ... }
    // we've defined ``rz`` on arbitrary physical qubits, so we can do:
    rz(3.14) $0;
    rz(3.14) $1;
@@ -75,7 +77,7 @@ physical qubits with different parameter values, e.g.
 Given multiple definitions of the same symbol, the compiler will match
 the most specific definition found for a given operation. Thus, given,
 
-#. ``defcal rx(angle[20] theta) $q  ...``
+#. ``defcal rx(angle[20] theta) q  ...``
 
 #. ``defcal rx(angle[20] theta) $0  ...``
 

--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -820,8 +820,8 @@ class CalibrationDefinition(Statement):
 
     Example::
 
-        defcal rz(angle[20] theta) $q {
-            shift_phase drive($q), -theta;
+        defcal rz(angle[20] theta) q {
+            shift_phase drive(q), -theta;
         }
     """
 

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -331,14 +331,9 @@ class QASMNodeVisitor(qasm3ParserVisitor):
             if ctx.argumentDefinitionList()
             else []
         )
-        qubits = (
-            [
-                add_span(ast.Identifier(qubit.getText()), get_span(qubit))
-                for qubit in ctx.hardwareQubitList().HardwareQubit()
-            ]
-            if ctx.hardwareQubitList()
-            else []
-        )
+        qubits = [
+            self.visit(argument) for argument in ctx.defcalArgumentList().defcalArgument() or []
+        ]
         return_type = (
             self.visit(ctx.returnSignature().scalarType()) if ctx.returnSignature() else None
         )
@@ -855,6 +850,12 @@ class QASMNodeVisitor(qasm3ParserVisitor):
                 get_span(array_ctx),
             )
         return ast.ExternArgument(type=type_, access=access)
+
+    @span
+    def visitDefcalArgument(self, ctx: qasm3Parser.DefcalArgumentContext):
+        if ctx.HardwareQubit():
+            return ast.Identifier(ctx.HardwareQubit().getText())
+        return _visit_identifier(ctx.Identifier())
 
     def visitStatementOrScope(
         self, ctx: qasm3Parser.StatementOrScopeContext

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -976,7 +976,7 @@ def test_calibration_grammar_declaration():
 
 def test_calibration_definition():
     p = """
-    defcal rz(angle[20] theta) $q -> bit { return shift_phase drive($q), -theta; }
+    defcal rz(angle[20] theta) q -> bit { return shift_phase drive(q), -theta; }
     """.strip()
     program = parse(p)
     assert _remove_spans(program) == Program(
@@ -989,9 +989,9 @@ def test_calibration_definition():
                         name=Identifier("theta"),
                     )
                 ],
-                qubits=[Identifier("$q")],
+                qubits=[Identifier("q")],
                 return_type=BitType(None),
-                body="return shift_phase drive ( $q ) , - theta ;",
+                body="return shift_phase drive ( q ) , - theta ;",
             )
         ]
     )


### PR DESCRIPTION
### Summary


This changes the wildcard identifier pattern from `$<identifier>` to
just being the identifier (for example `$q` to `q`).  Precise hardware
qubits such as `$0` are not affected.  The extra dollar sign did not
carry any information, since the wildcard applied to _all_ qubits, and
caused a strange discrepancy between what was a valid identifier in
different situations.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->


### Details and comments

This is as discussed in the TSC meeting on 2022-06-17, though we also recognised that there was originally a reason this `$` was present, and people might have remembered stronger opposition to making this change since that meeting.

Fixes a part of #367.