### PR TITLE
Correct surrounding OQ 3 code in OpenPulse examples

### DIFF
--- a/source/language/openpulse.rst
+++ b/source/language/openpulse.rst
@@ -404,12 +404,12 @@ discriminated using user-defined boxcar and discrimination ``extern``\s.
 
     defcalgrammar "openpulse";
 
-    // Use a boxcar function to generate IQ data from raw waveform
-    extern boxcar(waveform input) -> complex[float[64]];
-    // Use a linear discriminator to generate bits from IQ data
-    extern discriminate(complex[float[64]] iq) -> bit;
-
     cal {
+        // Use a boxcar function to generate IQ data from raw waveform
+        extern boxcar(waveform input) -> complex[float[64]];
+        // Use a linear discriminator to generate bits from IQ data
+        extern discriminate(complex[float[64]] iq) -> bit;
+
         // Define the ports
         extern port m0;
         extern port cap0;
@@ -713,7 +713,7 @@ Here we want to sweep the time of the pulse and observe coherent Rabi flopping d
   const duration pulse_length_step = 1dt;
   const int pulse_length_num_steps = 100;
 
-  for i in [1:pulse_length_num_steps] {
+  for int i in [1:pulse_length_num_steps] {
       duration pulse_length = pulse_length_start + (i-1)*pulse_length_step);
       duration sigma = pulse_length / 4;
       // since we are manipulating pulse lengths it is easier to define and play the waveform in a `cal` block

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -26,7 +26,7 @@ instruction sequence on *physical* qubits, e.g.
 
    defcal rz(angle[20] theta) $0 { ... }
    defcal measure $0 -> bit { ... }
-   defcal measure_iq q -> complex[32] { ... }
+   defcal measure_iq q -> complex[float[32]] { ... }
 
 We distinguish gate and measurement definitions by the presence of a
 return value type in the latter case, analogous to the subroutine syntax
@@ -123,7 +123,7 @@ a global scope to all identifiers in order to declare values shared across all `
    OPENQASM 3;
    defcalgrammar "openpulse";
 
-   const original_freq = 5.9e9;
+   const float original_freq = 5.9e9;
 
    cal {
       // Defined within `cal`, so it may not leak back out to the enclosing blocks scope
@@ -194,8 +194,8 @@ existing ``include`` mechanism.
 
    defcalgrammar "openpulse";
 
-   const q0_freq = 5.0e9;
-   const q1_freq = 5.1e9;
+   const float q0_freq = 5.0e9;
+   const float q1_freq = 5.1e9;
 
    cal {
 


### PR DESCRIPTION
### Summary

In some OpenPulse (or general pulse-grammar) examples where the embedded
of the calibration language inside OpenQASM 3 was being demonstrated,
the surrounding OQ 3 code was invalid.  This was mostly due to OpenPulse
types being given in `extern` statements; this would be an OpenPulse
extension, and so needs to be in `cal` block.

Examples which were _entirely_ in the pulse language are unchanged;
there's no advantage in wrapping everything in a `cal` statement, and it
just adds more noise for readers.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->


### Details and comments

Along with #371, fix the other part of #367.

Since #371 is now merged, this fixes #367.
