### PR TITLE
Make the semantic of `gphase();` clearer. 

### DIFF
--- a/source/language/gates.rst
+++ b/source/language/gates.rst
@@ -132,7 +132,15 @@ From a physical perspective, the gates :math:`e^{i\gamma}U` and :math:`U` are eq
 phase :math:`e^{i\gamma}`. When we add a control to these gates, however, the global phase becomes a relative phase
 that is applied when the control qubit is one. To capture the programmer's intent, a built-in global phase gate
 allows the inclusion of arbitrary global phases on circuits. The instruction ``gphase(γ);`` adds a global phase
-of :math:`e^{i\gamma}` to the scope containing the instruction. For example
+of :math:`e^{i\gamma}` to the gate, subroutine, or global scope which containing the instruction. This is equivalent to 
+adding an n-qubits global phase gate 
+
+.. math::
+
+   \text{gphase(γ)} := e^{i\gamma} I_{2^n}
+
+, where :math:`I_{2^n}` is an identity matrix with size :math:`2^n`, and n is the number of qubits declared in the scope.
+For example
 
 .. code-block::
 

--- a/source/language/gates.rst
+++ b/source/language/gates.rst
@@ -132,14 +132,14 @@ From a physical perspective, the gates :math:`e^{i\gamma}U` and :math:`U` are eq
 phase :math:`e^{i\gamma}`. When we add a control to these gates, however, the global phase becomes a relative phase
 that is applied when the control qubit is one. To capture the programmer's intent, a built-in global phase gate
 allows the inclusion of arbitrary global phases on circuits. The instruction ``gphase(γ);`` adds a global phase
-of :math:`e^{i\gamma}` to the gate, subroutine, or global scope which containing the instruction. This is equivalent to 
-adding an n-qubits global phase gate 
+of :math:`e^{i\gamma}` to the gate, subroutine, or global scope which containing the instruction.
+If :math:`n` qubits are in scope, this is equivalent to applying a gate
 
 .. math::
 
-   \text{gphase(γ)} := e^{i\gamma} I_{2^n}
+   \operatorname{gphase}(\gamma) := e^{i\gamma} I_n,
 
-, where :math:`I_{2^n}` is an identity matrix with size :math:`2^n`, and n is the number of qubits declared in the scope.
+where :math:`I_n` is an identity matrix with size :math:`2^n`.
 For example
 
 .. code-block::


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Make the semantic of `gphase();` clearer. See https://github.com/openqasm/openqasm/issues/383 .
This definition of `gphase()` also allows accumulation.

### Details and comments

The semantic of `gphase();` in Amazon Braket is just add a global phase gate to the containing scope. No matter which qubit is applied to, the result state of the circuit is the same. In this case, an n-qubits global phase gate is more reasonable.

If someone just want the state of a specific qubit, this design cannot distinguish which qubit `gphase();` applies to.

The *"scope"* is also more specific. Only gate, subroutine, and global scope have qubits declaration/definition. If we only limit to the containing scope, for example, the `for` scope, the semantic can also be *"do nothing"* because no qubits declared/defined in the `for` scope.


