### PR TITLE
Increment the OpenQASM3 reference parser version to 0.2.0

### DIFF
--- a/source/openqasm/openqasm3/__init__.py
+++ b/source/openqasm/openqasm3/__init__.py
@@ -14,7 +14,7 @@ With the ``[parser]`` extra installed, the simplest interface to the parser is
 the :obj:`~parser.parse` function.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 from . import ast, visitor, properties
 


### PR DESCRIPTION
### Summary

Increment the version of reference parser so that we can publish a new package.

### Details and comments

I tagged my local branch with `py/v0.2.0`. Not sure if the tag is transferred to the PR. If not, we need to tag separately.


