### PR TITLE
Fix space in barrier without argument

### DIFF
--- a/source/openqasm/openqasm3/printer.py
+++ b/source/openqasm/openqasm3/printer.py
@@ -467,8 +467,10 @@ class Printer(QASMVisitor[PrinterState]):
     @_maybe_annotated
     def visit_QuantumBarrier(self, node: ast.QuantumBarrier, context: PrinterState) -> None:
         self._start_line(context)
-        self.stream.write("barrier ")
-        self._visit_sequence(node.qubits, context, separator=", ")
+        self.stream.write("barrier")
+        if node.qubits:
+            self.stream.write(" ")
+            self._visit_sequence(node.qubits, context, separator=", ")
         self._end_statement(context)
 
     @_maybe_annotated

--- a/source/openqasm/tests/test_printer.py
+++ b/source/openqasm/tests/test_printer.py
@@ -488,6 +488,7 @@ barrier q;
 barrier $0;
 barrier q[0];
 barrier q[1:3];
+barrier;
 """.strip()
         output = openqasm3.dumps(openqasm3.parse(input_)).strip()
         assert output == input_


### PR DESCRIPTION
This commit add a space in barrier only when it is called with arguments.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary
Fixes issue #389


### Details and comments
Similar to fix for delay[duration];
