### PR TITLE
Forbid qubit aliasing in subroutine calls

### DIFF
--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -14,7 +14,7 @@ the subroutine by reference or name, while classical types are passed in by valu
 All arguments are declared together with their type. For example, ``qubit ancilla``
 defines a quantum bit argument named ``ancilla``.
 
-A given qubit can passed at most once in any subroutine call.  Different
+A given qubit can be passed at most once in any subroutine call.  Different
 ``qubit`` arguments (whether single bits or registers) cannot refer to the same
 underlying qubit in a call.
 

--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -14,6 +14,10 @@ the subroutine by reference or name, while classical types are passed in by valu
 All arguments are declared together with their type. For example, ``qubit ancilla``
 defines a quantum bit argument named ``ancilla``.
 
+A given qubit can passed at most once in any subroutine call.  Different
+``qubit`` arguments (whether single bits or registers) cannot refer to the same
+underlying qubit in a call.
+
 Subroutines return up to one value of classical type, signified by the
 ``return`` keyword. If there is no return value, the empty ``return``
 keyword may be used to immediately exit from the subroutine, which implicitly


### PR DESCRIPTION
### Summary

This restriction was discussed in the TSC meeting on 2022-09-02, to avoid complications in the definition of `gphase` within subroutine scopes, and to ease implementations.  It may be reasonable to lift the restriction in a later language version.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->


### Details and comments


