### PR TITLE
Reserve switch keywords

### DIFF
--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -450,6 +450,13 @@ In our computational model, ``extern`` functions may run concurrently with other
 quantum computations. That is, invoking an ``extern`` function will  *schedule* a classical
 computation, but does not wait for that computation to terminate.
 
+
+Further reserved keywords
+-------------------------
+
+The keywords ``switch``, ``case`` and ``default`` are reserved for future
+expansion of the language.  These words are not valid identifiers.
+
 .. [1]
    ``popcount`` computes the Hamming weight of the input register.
 


### PR DESCRIPTION
### Summary

From TSC meeting 2022-09-02, we anticpate expanding the OpenQASM 3 language with these keywords, but they may not fully be in time for OpenQASM 3.0.  It's easier to allow something previously forbidden than the opposite, so we are taking this step proactively.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->


### Details and comments

This PR may be obsoleted by one that more completely adds `switch` and `case` support.
