### PR TITLE
Update example for indexes

### DIFF
--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -825,7 +825,7 @@ variables whose values may only be known at run time.
    let last = concatenated[-1];
    // Qubits zero, three and five
    let qubit_selection = two[{0, 3, 5}];
-   // First six qubits in aliased qubit array
+   // First seven qubits in aliased qubit array
    let sliced = concatenated[0:6];
    // Every second qubit
    let every_second = concatenated[0:2:12];


### PR DESCRIPTION
### Summary

One of the indexing examples isn't consistent with the definition, according to my read of the spec.

### Details and comments

Here's the definition:

<img width="693" alt="image" src="https://user-images.githubusercontent.com/155646/195444926-e723a1b8-e264-4f33-9fb7-ecd25255cb52.png">

`a = 0`, `b = 6`, and `c = 1` (by default). The largest integer m such that `a + mc <= b` is `m=6`, so there will be seven entries in the output array.