### PR TITLE
Add deployment pipeline for reference AST

### DIFF
--- a/.github/workflows/deploy-ast.yml
+++ b/.github/workflows/deploy-ast.yml
@@ -1,0 +1,68 @@
+name: Deploy Reference Python Package
+
+on:
+  push:
+    tags:
+      - 'ast-py/v*'
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-ast.yml
+
+  deploy:
+    name: Deploy to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      # There's deliberately no check-out step here, because we don't want the
+      # checkout anywhere near us complicating matters; we're just trying to
+      # ensure that the pre-built wheel works, and its version matches what we
+      # expect from the tag.
+
+      - uses: actions/setup-python@v3
+        with:
+          # The version checker uses 'importlib.metadata' which is Python 3.10+.
+          python-version: '3.10'
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: openqasm3-python-wheel
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: openqasm3-python-sdist
+
+      - name: Verify package
+        run: |
+          set -e
+          python3 -mvenv .venv
+          source .venv/bin/activate
+
+          python3 -mpip install -U pip wheel
+          python3 -mpip install openqasm3-*.whl
+
+          # Extract the version information from the end of the tag.
+          tag_version=${GITHUB_REF#refs/tags/ast-py/v}
+          # We could get this from the wheel filename too, but it's easier to
+          # test with Python built-ins.
+          wheel_version=$(python3 -c 'from importlib.metadata import version; print(version("openqasm3"))')
+
+          if [[ "$tag_version" != "$wheel_version" ]]; then
+            echo "Version mismatch: tag says '$tag_version', wheel says '$wheel_version'" >&2
+            exit 1
+          fi
+
+          # Last-ditch validity check that the wheel actually imports.
+          python3 -c 'import openqasm3'
+
+      - name: Upload to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.OPENQASM_BOT_PYPI_TOKEN }}
+        run: |
+          set -e
+          source .venv/bin/activate
+
+          python3 -mpip install -U twine
+          twine upload openqasm3-*.whl openqasm3-*.tar.gz

--- a/source/openqasm/README.md
+++ b/source/openqasm/README.md
@@ -81,3 +81,18 @@ black .
 pylint .
 pytest
 ```
+
+
+### Deployment procedure
+
+The deployment is primarily managed by a GitHub Actions pipeline, triggered by a tag of the form `ast-py/v<version>`.
+For example, for package version `0.4.0`, the tag should be `ast-py/v0.4.0`.
+
+To deploy:
+
+1. create a PR that sets the version number of the package in `__init__.py` and `docs/conf.py` to what it should be.
+2. once the PR has merged, tag the merge commit (for example, `git fetch origin; git tag -m "Python AST 0.4.0" ast-py/v0.4.0 origin/main`).
+3. push the tag to this repository (for example, `git push origin ast-py/v0.4.0`).
+
+At this point, the deployment pipeline will take over and deploy the package to PyPI.
+You should be able to see the progress [in the Actions tab of this repository](https://github.com/openqasm/openqasm/actions/workflows/deploy-ast.yml).


### PR DESCRIPTION
### Summary

This adds a GitHub Action for handling the build and deployment of the reference Python package.  This should remove the possibility for user error when building the package (especially important now that there are many ANTLR versions to be built), and allows anybody with tag-push access to the repository to cut a release.

The action verifies that the package builds, installs and imports, but we leave testing to the CI that should have run before any PR was merged.  We also verify that the tag version matches the version information in the wheel; this is mostly just a sanity check that what we're releasing is what we expect.  PyPI will reject any uploads for a version that has already been released.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->


### Details and comments


