### PR TITLE
Remove version string from most examples, two have been left intentionally

### DIFF
--- a/examples/adder.qasm
+++ b/examples/adder.qasm
@@ -2,7 +2,6 @@
  * quantum ripple-carry adder
  * Cuccaro et al, quant-ph/0410184
  */
-OPENQASM 3;
 include "stdgates.inc";
 
 gate majority a, b, c {

--- a/examples/alignment.qasm
+++ b/examples/alignment.qasm
@@ -3,7 +3,6 @@
  * specify design intent on gate alignment, without
  * being tied to physical qubits and gates.
 */
-OPENQASM 3.0;
 include "stdgates.inc";
 
 stretch g;

--- a/examples/dd.qasm
+++ b/examples/dd.qasm
@@ -2,7 +2,6 @@
  * This example demonstrates the use of referential delays
  * and time alignment.
 */
-OPENQASM 3.0;
 include "stdgates.inc";
 
 stretch a;

--- a/examples/gateteleport.qasm
+++ b/examples/gateteleport.qasm
@@ -1,5 +1,4 @@
 // Repetition code gate teleportation
-OPENQASM 3;
 include "stdgates.inc";
 
 // declarations

--- a/examples/inverseqft1.qasm
+++ b/examples/inverseqft1.qasm
@@ -1,5 +1,4 @@
 // QFT and measure, version 1
-OPENQASM 3;
 include "stdgates.inc";
 
 qubit[4] q;

--- a/examples/inverseqft2.qasm
+++ b/examples/inverseqft2.qasm
@@ -1,5 +1,4 @@
 // QFT and measure, version 2
-OPENQASM 3;
 include "stdgates.inc";
 
 qubit[4] q;

--- a/examples/ipe.qasm
+++ b/examples/ipe.qasm
@@ -1,7 +1,6 @@
 /*
  * Iterative phase estimation
  */
-OPENQASM 3;
 include "stdgates.inc";
 
 const int[32] n = 10;          // number of iterations

--- a/examples/msd.qasm
+++ b/examples/msd.qasm
@@ -1,7 +1,6 @@
 /*
  * Magic state distillation and computation
  */
-OPENQASM 3;
 include "stdgates.inc";
 
 const int[32] buffer_size = 6;  // size of magic state buffer

--- a/examples/qec.qasm
+++ b/examples/qec.qasm
@@ -1,5 +1,4 @@
 // Repetition code syndrome measurement
-OPENQASM 3;
 include "stdgates.inc";
 
 qubit[3] q;

--- a/examples/qft.qasm
+++ b/examples/qft.qasm
@@ -1,5 +1,4 @@
 // quantum Fourier transform
-OPENQASM 3;
 include "stdgates.inc";
 qubit[4] q;
 bit[4] c;

--- a/examples/qpt.qasm
+++ b/examples/qpt.qasm
@@ -1,4 +1,3 @@
-OPENQASM 3;
 include "stdgates.inc";
 
 gate pre q { }   // pre-rotation

--- a/examples/rb.qasm
+++ b/examples/rb.qasm
@@ -1,5 +1,4 @@
 // One randomized benchmarking sequence
-OPENQASM 3;
 include "stdgates.inc";
 
 qubit[2] q;

--- a/examples/rus.qasm
+++ b/examples/rus.qasm
@@ -2,7 +2,6 @@
  * Repeat-until-success circuit for Rz(theta),
  * cos(theta-pi)=3/5, from Nielsen and Chuang, Chapter 4.
  */
-OPENQASM 3;
 include "stdgates.inc";
 
 /*

--- a/examples/scqec.qasm
+++ b/examples/scqec.qasm
@@ -4,7 +4,6 @@
  * Estimate the failure probability as a function
  * of parameters at the top of the file.
  */
-OPENQASM 3;
 include "stdgates.inc";
 
 const int[32] d = 3;         // code distance

--- a/examples/t1.qasm
+++ b/examples/t1.qasm
@@ -1,7 +1,6 @@
 /* Measuring the relaxation time of a qubit
  * This example demonstrates the repeated use of fixed delays.
 */
-OPENQASM 3.0;
 include "stdgates.inc";
 
 duration stride = 1us;            // time resolution of points taken

--- a/examples/varteleport.qasm
+++ b/examples/varteleport.qasm
@@ -2,7 +2,6 @@
  * Prepare a parameterized number of Bell pairs
  * and teleport a qubit using them.
  */
-OPENQASM 3;
 include "stdgates.inc";
 
 const int[32] n_pairs = 10;  // number of teleportations to do

--- a/examples/vqe.qasm
+++ b/examples/vqe.qasm
@@ -5,7 +5,6 @@
  * The parameters are updated outside of this program and a new
  * OpenQASM circuit is generated for the next iteration.
  */
-OPENQASM 3;
 include "stdgates.inc";
 
 const int[32] n = 10;         // number of qubits


### PR DESCRIPTION
### Summary
As discussed at the TSC meeting on October 14th, this PR removes the OPENQASM version string from most of the examples

### Details and comments
The version string is optional, and leaving it out is the general default. It was originally included to enable any potential breaking changes to be included, but since we have been able to maintain backward compatibility it is mostly unnecessary, and the TSC decided that compilers should/can decide for themselves which parser to use based on the features in the translation unit being parsed.

