### PR TITLE
Add support for defcal delay with square brackets to grammar

### DIFF
--- a/source/grammar/qasm3Parser.g4
+++ b/source/grammar/qasm3Parser.g4
@@ -203,7 +203,7 @@ arrayReferenceType: (READONLY | MUTABLE) ARRAY LBRACKET scalarType COMMA (expres
 
 designator: LBRACKET expression RBRACKET;
 
-defcalTarget: MEASURE | RESET | DELAY | Identifier;
+defcalTarget: MEASURE | RESET | DELAY LBRACKET Identifier RBRACKET | Identifier;
 defcalArgumentDefinition: expression | argumentDefinition;
 defcalOperand: HardwareQubit | Identifier;
 gateOperand: indexedIdentifier | HardwareQubit;

--- a/source/grammar/tests/reference/pulse/defcal.yaml
+++ b/source/grammar/tests/reference/pulse/defcal.yaml
@@ -3,6 +3,7 @@ source: |
   defcal measure $0 -> bit {Outer {nested} outer}
   defcal rz(angle[20] theta) q {£$&£*(")}
   defcal rz(pi / 2) q {Symbolic expression.}
+  defcal delay[time] q {delay[time] frame_1; delay[time] frame_2;}
 reference: |
   program
     statement
@@ -74,5 +75,19 @@ reference: |
             q
         {
         Symbolic expression.
+        }
+    statement
+      defcalStatement
+        defcal
+        defcalTarget
+          delay
+          [
+          time
+          ]
+        defcalOperandList
+          defcalOperand
+            q
+        {
+        delay[time] frame_1; delay[time] frame_2;
         }
     <EOF>

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -27,8 +27,11 @@ instruction sequence on *physical* qubits, e.g.
 
    defcal rz(angle[20] theta) $0 { ... }
    defcal measure $0 -> bit { ... }
+   defcal delay[time] $0 { ... }
    defcal measure_iq q -> complex[float[32]] { ... }
 
+defcals may be defined for the qubit ``measure``, ``reset``, ``delay`` operators as
+well as for arbitrarily named gates.
 We distinguish gate and measurement definitions by the presence of a
 return value type in the latter case, analogous to the subroutine syntax
 defined earlier. Furthermore, the return value type does not need to return a

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -331,6 +331,20 @@ class QASMNodeVisitor(qasm3ParserVisitor):
             self.visit(ctx.returnSignature().scalarType()) if ctx.returnSignature() else None
         )
 
+        defcal_target: qasm3Parser.DefcalTargetContext = ctx.defcalTarget()
+        if defcal_target.DELAY():
+            duration_ident = defcal_target.Identifier()
+            span = get_span(duration_ident)
+            arguments.append(
+                add_span(
+                    ast.ClassicalArgument(
+                        type=add_span(ast.DurationType(), span=span),
+                        name=add_span(ast.Identifier(duration_ident.getText()), span=span)
+                    ),
+                    span=span,
+                )
+            )
+
         return ast.CalibrationDefinition(
             name=self.visit(ctx.defcalTarget()),
             arguments=arguments,
@@ -793,6 +807,8 @@ class QASMNodeVisitor(qasm3ParserVisitor):
 
     @span
     def visitDefcalTarget(self, ctx: qasm3Parser.DefcalTargetContext):
+        if ctx.DELAY():
+            return ast.Identifier(name="delay")
         return ast.Identifier(name=ctx.getText())
 
     @span

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -1056,6 +1056,7 @@ def test_calibration_definition():
     defcal measure $0 -> bit {Outer {nested} outer again.}
     defcal rx(pi / 2) $1 {Untokenisable: *$£()"*}
     defcal cx $0, $1 {}
+    defcal delay[time] q { delay[time] frame_1; delay[time] frame_2; }
     """.strip()
     program = parse(p)
     assert _remove_spans(program) == Program(
@@ -1099,6 +1100,14 @@ def test_calibration_definition():
                 return_type=None,
                 body="",
             ),
+            CalibrationDefinition(
+                name=Identifier("delay"),
+                arguments=[ClassicalArgument(DurationType(), Identifier("time"))],
+                qubits=[Identifier("q")],
+                return_type=None,
+                body=" delay[time] frame_1; delay[time] frame_2; "
+
+            )
         ]
     )
     SpanGuard().visit(program)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Closes issue #398 

### Details and comments

This add support for the following syntax:

```
defcal delay[duration_name] qubit_name { ... }
```

When parsing this the resulting ast node is a `CalibrationDefinition` where `name` is "delay" and `arguments` has a single `ClassicalArgument` entry with type `DurationType` and name `duration_name`. That is to say, the node parses as if the user had written 

```
defcal delay(duration duration_name) qubit_name { ... }
```