### PR TITLE
Modify ExternStatement AST node

### DIFF
--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -231,7 +231,7 @@ class ExternDeclaration(Statement):
 
     name: Identifier
     arguments: List[ExternArgument]
-    return_type: Optional[ExternArgument] = None
+    return_type: Optional[ClassicalType] = None
 
 
 class Expression(QASMNode):

--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -52,6 +52,7 @@ __all__ = [
     "EndStatement",
     "Expression",
     "ExpressionStatement",
+    "ExternArgument",
     "ExternDeclaration",
     "FloatLiteral",
     "FloatType",

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -410,25 +410,55 @@ def test_array_declaration():
 
 def test_extern_declarations():
     p = """
-    extern constant(duration, float[64]) -> float[64];
-    extern set_readout(int);
+    extern f();
+    extern f() -> bool;
+    extern f(bool);
+    extern f(int[32], uint[32]);
+    extern f(mutable array[complex[float[64]], N_ELEMENTS]) -> int[2 * INT_SIZE];
     """.strip()
     program = parse(p)
     assert _remove_spans(program) == Program(
         statements=[
             ExternDeclaration(
-                name=Identifier(name="constant"),
-                arguments=[
-                    ExternArgument(type=DurationType()),
-                    ExternArgument(type=FloatType(IntegerLiteral(64))),
-                ],
-                return_type=FloatType(IntegerLiteral(64)),
+                name=Identifier(name="f"),
+                arguments=[],
             ),
             ExternDeclaration(
-                name=Identifier(name="set_readout"),
+                name=Identifier(name="f"),
+                arguments=[],
+                return_type=BoolType(),
+            ),
+            ExternDeclaration(
+                name=Identifier(name="f"),
                 arguments=[
-                    ExternArgument(type=IntType()),
+                    ExternArgument(type=BoolType()),
                 ],
+            ),
+            ExternDeclaration(
+                name=Identifier(name="f"),
+                arguments=[
+                    ExternArgument(type=IntType(IntegerLiteral(32))),
+                    ExternArgument(type=UintType(IntegerLiteral(32))),
+                ],
+            ),
+            ExternDeclaration(
+                name=Identifier(name="f"),
+                arguments=[
+                    ExternArgument(
+                        type=ArrayReferenceType(
+                            base_type=ComplexType(FloatType(IntegerLiteral(64))),
+                            dimensions=[Identifier(name="N_ELEMENTS")],
+                        ),
+                        access=AccessControl["mutable"],
+                    ),
+                ],
+                return_type=IntType(
+                    size=BinaryExpression(
+                        op=BinaryOperator["*"],
+                        lhs=IntegerLiteral(2),
+                        rhs=Identifier(name="INT_SIZE"),
+                    )
+                ),
             ),
         ]
     )

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -35,6 +35,8 @@ from openqasm3.ast import (
     DurationType,
     EndStatement,
     ExpressionStatement,
+    ExternArgument,
+    ExternDeclaration,
     FloatLiteral,
     FloatType,
     ForInLoop,
@@ -404,6 +406,33 @@ def test_array_declaration():
             ),
         ],
     )
+
+
+def test_extern_declarations():
+    p = """
+    extern constant(duration, float[64]) -> float[64];
+    extern set_readout(int);
+    """.strip()
+    program = parse(p)
+    assert _remove_spans(program) == Program(
+        statements=[
+            ExternDeclaration(
+                name=Identifier(name="constant"),
+                arguments=[
+                    ExternArgument(type=DurationType()),
+                    ExternArgument(type=FloatType(IntegerLiteral(64))),
+                ],
+                return_type=FloatType(IntegerLiteral(64)),
+            ),
+            ExternDeclaration(
+                name=Identifier(name="set_readout"),
+                arguments=[
+                    ExternArgument(type=IntType()),
+                ],
+            ),
+        ]
+    )
+    SpanGuard().visit(program)
 
 
 def test_single_gatecall():


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.
Yes

Are you changing the grammar to adjust to the specification?
No

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary
We change the return_type node of ExternStatement from Optional[ExternalArgument] to Optional[ClassicalType]. 

### Details and comments
This PR also adds parsing tests for ExternStatement and export ExternArgument.

Close #409 

