### PR TITLE
RFC: Use extern constructors for arbitrary waveforms in the OpenPulse spec

### DIFF
--- a/source/language/openpulse.rst
+++ b/source/language/openpulse.rst
@@ -237,7 +237,7 @@ Waveforms
 ---------
 
 OpenPulse introduces a new type, ``waveform``. Within the language itself, waveforms are
-somewhat opaque object. They may be constructed and used as arguments for operators
+somewhat opaque objects. They may be constructed and used as arguments for operators
 which accept waveforms (e.g. the ``play`` instruction below).
 
 Ultimately, waveforms are realized as a sequence of samples which define the points of


### PR DESCRIPTION
### Summary

This proposes a revision to the OpenPulse spec, in which the special square bracket syntax `[0.1+0.1im, 0.2+0.2im]` is replaced by a notion of variadic waveform constructor, e.g. `arb(0.1+0.1im, 0.2+0.2im)`. h/t @stevenheidel 

Note: This PR presents an alternative to the effort associated with [this MR](https://github.com/openqasm/openpulse-python/pull/12) for waveform literal handling in the OpenPulse reference parser. Some more information about design tradeoffs associated with waveform literals vs array literals may be found in that link.

### Details and comments

There is a clear need for arbitrary waveforms in OpenPulse, but it's not clear that having a special syntax for them is entirely justified. Likewise, there are complications with overloading array literal syntax for this purpose. 

A significant upside to the square bracket syntax is that it makes writing a certain kind of arbitrary waveform (e.g. defined by a list of complex samples) very comfortable. However, implementors may find it useful to support more than one sort of arbitrary waveform. For example
1. In addition to allowing an explicit list of complex IQ values, it may be useful to allow for a list of (implementation specific) integer DAC codewords.
2. There may be some other variadic constructors which are meaningful, e.g. constructing a piecewise constant or piecewise linear waveforms.

By using the same `extern` notion as is used by parametric waveforms, the above could be handled gracefully, e.g.
1. `dacwaveform(32768, 32767, 32766, 32765, ...)`
2. `step(16ns, 0.1, 0.2, 0.3, 0.4)` and `ramp(16ns, 0.1, 0.2, 0.3, 0.4)`

I have tried to give sufficient room in the spec for implementors to freely experiment with these notions. In particular, I have stressed that the available set of waveform constructors, and their arguments, is implementation specific.

The primary difficulty with the changes in this PR is that OpenQASM does not have any notion of variadic functions, and so even the type signature of the `extern` constructors would be out of spec. I do not think this is a significant problem for implementors, since the actual constructor calls are syntactically legal, and presumably there is already some special treatment of waveform constructors, relative to ordinary function calls. But if we go ahead with the changes in this PR, we need to be mindful of future implications should OpenQASM or OpenPulse wish to introduce first-class variadic functions.


