### PR TITLE
Allow DurationType as scalar type for arrays

### DIFF
--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -704,6 +704,12 @@ can be accessed, using the following general syntax:
    multiDim[0, 0] = 0.0; // multiDim == {{0.0, 1.2}, {2.1, 2.2}, {3.1, 3.2}}
    multiDim[-1, 1] = 0.0; // multiDim == {{0.0, 1.2}, {2.1, 2.2}, {3.1, 0.0}}
 
+The first argument to the ``array`` type constructor is the base type
+of the array. The supported classical types include various sizes of ``bit``,
+``int``, ``uint``, ``float``, ``complex``, and ``angle``, as well as
+``bool`` and ``duration``. Note that ``stretch`` is not a valid array
+base type.
+
 Arrays *cannot* be declared inside the body of a function or gate. All arrays
 *must* be declared within the global scope of the program.
 Indexing of arrays is n-based *i.e.*, negative indices are allowed.

--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -779,7 +779,7 @@ class ArrayType(ClassicalType):
     arrays declared by being arguments to subroutines.
     """
 
-    base_type: Union[IntType, UintType, FloatType, AngleType, BitType, BoolType, ComplexType]
+    base_type: Union[IntType, UintType, FloatType, AngleType, DurationType, BitType, BoolType, ComplexType]
     dimensions: List[Expression]
 
 
@@ -801,7 +801,7 @@ class ArrayReferenceType(ClassicalType):
         def f(const array[uint[8], #dim=3] b) {}
     """
 
-    base_type: Union[IntType, UintType, FloatType, AngleType, BitType, BoolType, ComplexType]
+    base_type: Union[IntType, UintType, FloatType, AngleType, DurationType, BitType, BoolType, ComplexType]
     dimensions: Union[Expression, List[Expression]]
 
 

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -775,6 +775,7 @@ class QASMNodeVisitor(qasm3ParserVisitor):
                 ast.UintType,
                 ast.FloatType,
                 ast.AngleType,
+                ast.DurationType,
                 ast.BoolType,
                 ast.ComplexType,
             ),


### PR DESCRIPTION
### Summary

This PR allows for array types with duration scalars.

I don't know whether the previous omission of `DurationType` was intentional or not. However,
1. There does not appear to be any discussion in [the spec](https://openqasm.com/language/types.html#arrays) explicitly restricting the set of scalar types. So I think this should be syntactically valid, even if particular implementors do not currently support it.
2. We  allow `for` loops over durations, e.g. `for duration delta in {0us, 1.0us, 2.0us, 3.0us} { ... }`. Currently the parser handles via a special rule for set expressions, but [the spec indicates](https://openqasm.com/language/classical.html#for-loops)  that this is array-literal syntax. There's no reason, in principle, why we should accept this but reject the equivalent where a user declares a duration array and loops over the index range.

