### PR TITLE
Cite Wikipedia as external reference on Unicode

### DIFF
--- a/source/bibliography.bib
+++ b/source/bibliography.bib
@@ -387,12 +387,15 @@
   publisher={Addison-Wesley Reading}
 }
 
-@misc{noauthorUnicodeNodate,
-	title = {Unicode {Character} {Categories}},
-	url = {http://www.fileformat.info/info/unicode/category/index.htm},
-	urldate = {2020-10-23},
-	file = {Unicode Character Categories:/Users/thomas/Zotero/storage/635ZUVZE/index.html:text/html}
+
+@misc{wikipediaUnicode,
+  author = "{Wikipedia contributors}",
+  title = "Unicode character property, General Category --- {Wikipedia}{,} The Free Encyclopedia",
+  year = "2022",
+  url = "https://en.wikipedia.org/w/index.php?title=Unicode_character_property&oldid=1114571327#General_Category",
+  note = "[Online; accessed 14-December-2022]"
 }
+
 
 @misc{khammassi18,
       title={cQASM v1.0: Towards a Common Quantum Assembly Language},

--- a/source/bibliography.bib
+++ b/source/bibliography.bib
@@ -387,15 +387,13 @@
   publisher={Addison-Wesley Reading}
 }
 
-
 @misc{wikipediaUnicode,
-  author = "{Wikipedia contributors}",
+  author = "Wikipedia contributors",
   title = "Unicode character property, General Category --- {Wikipedia}{,} The Free Encyclopedia",
   year = "2022",
   url = "https://en.wikipedia.org/w/index.php?title=Unicode_character_property&oldid=1114571327#General_Category",
   note = "[Online; accessed 14-December-2022]"
 }
-
 
 @misc{khammassi18,
       title={cQASM v1.0: Towards a Common Quantum Assembly Language},

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -11,7 +11,7 @@ Identifiers
 -----------
 
 Identifiers must begin with a letter [A-Za-z], an underscore or an element from
-the Unicode character categories Lu/Ll/Lt/Lm/Lo/Nl :cite:`noauthorUnicodeNodate`.
+the Unicode character categories Lu/Ll/Lt/Lm/Lo/Nl :cite:`wikipediaUnicode`.
 The set of permissible continuation characters consists of all members of the
 aforementioned character sets with the addition of decimal numerals [0-9].
 Identifiers may not override a reserved identifier.


### PR DESCRIPTION
The previously linked site had a very large number of intrusive advertisements and little information.

Closes #425

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Use a better reference for the external link to a reference on unicode characters.


### Details and comments

Use wikipedia. Use wikipedias page-citation generator.
