### PR TITLE
Remove description of Boolean literal as "string"

### DIFF
--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -660,7 +660,7 @@ exponent.
    float f5 = 2e+1; // scientific with positive signed exponent
    float f6 = 2.0E-1; // uppercase scientific with signed exponent
 
-The two boolean literals are the lowercase strings ``true`` and ``false``.
+The two boolean literals are ``true`` and ``false``.
 
 Bit string literals are denoted by double quotes ``"`` surrounding a number of
 zero and one digits, and may include non-consecutive underscores to improve


### PR DESCRIPTION
Closes #424

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Replace
> boolean literals are the lowercase strings `true` and `false`.

with

> boolean literals are `true` and `false`.
