### PR TITLE
In scan for TimeUnit fragment allow two unicode representations of mu

### DIFF
--- a/source/grammar/qasm3Lexer.g4
+++ b/source/grammar/qasm3Lexer.g4
@@ -147,7 +147,8 @@ FloatLiteral:
     // 123.456, 123. or 145.32e+1_00
     | DecimalIntegerLiteral DOT DecimalIntegerLiteral? FloatLiteralExponent?;
 
-fragment TimeUnit: 'dt' | 'ns' | 'us' | 'µs' | 'ms' | 's';
+// Each of the two unicode literals represent the greek letter mu.
+fragment TimeUnit: 'dt' | 'ns' | 'us' | '\u{00B5}s' | '\u{03BC}s' | 'ms' | 's';
 // represents explicit time value in SI or backend units
 TimingLiteral: (DecimalIntegerLiteral | FloatLiteral) TimeUnit;
 

--- a/source/grammar/tests/reference/declaration/declaration.yaml
+++ b/source/grammar/tests/reference/declaration/declaration.yaml
@@ -21,6 +21,9 @@ source: |
   float[32] f = .1e+3;
   duration dur = 1000dt;
   duration dur2 = dur + 200ns;
+  duration dur3a = 1μs;
+  duration dur3b = 1μs;
+  duration dur3c = 1us;
   stretch s;
 reference: |
   program
@@ -289,6 +292,36 @@ reference: |
             +
             expression
               200ns
+        ;
+    statement
+      classicalDeclarationStatement
+        scalarType
+          duration
+        dur3a
+        =
+        declarationExpression
+          expression
+            1μs
+        ;
+    statement
+      classicalDeclarationStatement
+        scalarType
+          duration
+        dur3b
+        =
+        declarationExpression
+          expression
+            1μs
+        ;
+    statement
+      classicalDeclarationStatement
+        scalarType
+          duration
+        dur3c
+        =
+        declarationExpression
+          expression
+            1us
         ;
     statement
       classicalDeclarationStatement


### PR DESCRIPTION
Previously only one unicode character for mu was recognized as the literal for microsecond. Now two are recognized. The new one appears frequently in Python. It also is used in qss-qasm.

Add tests for the three ways to specify microsecond.

Closes #422

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Recognize two different characters representing mu in the Lexer. Write them as unicode literals in order to remove ambiguity, since the glyphs are typically indistinguishable.



