### PR TITLE
Make `IndexedIdentifier` an `Expression`

### DIFF
--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -461,7 +461,7 @@ class IndexExpression(Expression):
 
 
 @dataclass
-class IndexedIdentifier(QASMNode):
+class IndexedIdentifier(Expression):
     """An indentifier with index operators, such that it can be used as an
     lvalue.  The list of indices is subsequent index brackets, so in::
 


### PR DESCRIPTION
### Summary

This makes the AST `IndexedIdentifier` a subclass of `Expression`.

### Details and comments

`IndexedIdentifier` are lvalue expressions (can be used on the left-hand side of an assignment) like `a[{1, 2, 3}][0:1, 0:1]`.  There is no apparent reason for this to not subclass `Expression`.

It's worth noting what this PR does not change: the grammar. The grammar has an [`expression` rule](https://github.com/openqasm/openqasm/blob/main/source/grammar/qasm3Parser.g4#L121) which does not include `indexedIdentifier`. However, the AST class hierarchy is already not 1-1 with the grammar (e.g. `ArrayLiteral` is an `Expression` in the AST but not part of the `expression` rule in the grammar), and I think this is fine. Grammars deal with concrete syntax & must satisfy certain constraints (e.g. for ANTLR) that are not relevant at the AST level.

