### PR TITLE
Add AST node type HardwareQubitIdentifier

### DIFF
--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -59,6 +59,7 @@ __all__ = [
     "ForInLoop",
     "FunctionCall",
     "GateModifierName",
+    "HardwareQubitIdentifier",
     "IODeclaration",
     "IOKeyword",
     "Identifier",
@@ -247,6 +248,20 @@ class Identifier(Expression):
     Example::
 
         q1
+
+    """
+
+    name: str
+
+
+@dataclass
+class HardwareQubitIdentifier(Expression):
+    """
+    An identifier referencing a hardware (physical) qubit.
+
+    Example::
+
+        $0
 
     """
 
@@ -510,7 +525,7 @@ class QuantumGate(QuantumStatement):
     modifiers: List[QuantumGateModifier]
     name: Identifier
     arguments: List[Expression]
-    qubits: List[Union[IndexedIdentifier, Identifier]]
+    qubits: List[Union[IndexedIdentifier, Identifier, HardwareQubitIdentifier]]
     duration: Optional[Expression] = None
 
 
@@ -551,7 +566,7 @@ class QuantumPhase(QuantumStatement):
 
     modifiers: List[QuantumGateModifier]
     argument: Expression
-    qubits: List[Union[IndexedIdentifier, Identifier]]
+    qubits: List[Union[IndexedIdentifier, Identifier, HardwareQubitIdentifier]]
 
 
 # Not a full expression because it can only be used in limited contexts.
@@ -565,7 +580,7 @@ class QuantumMeasurement(QASMNode):
         measure q;
     """
 
-    qubit: Union[IndexedIdentifier, Identifier]
+    qubit: Union[IndexedIdentifier, Identifier, HardwareQubitIdentifier]
 
 
 # Note that this is not a QuantumStatement because it involves access to
@@ -604,7 +619,7 @@ class QuantumReset(QuantumStatement):
         reset q;
     """
 
-    qubits: Union[IndexedIdentifier, Identifier]
+    qubits: Union[IndexedIdentifier, Identifier, HardwareQubitIdentifier]
 
 
 @dataclass
@@ -1003,7 +1018,7 @@ class DelayInstruction(QuantumStatement):
     """
 
     duration: Expression
-    qubits: List[Union[IndexedIdentifier, Identifier]]
+    qubits: List[Union[IndexedIdentifier, Identifier, HardwareQubitIdentifier]]
 
 
 @dataclass
@@ -1056,7 +1071,7 @@ class AliasStatement(Statement):
     """
 
     target: Identifier
-    value: Union[Identifier, Concatenation]
+    value: Union[Identifier, Concatenation, HardwareQubitIdentifier]
 
 
 @dataclass

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -129,6 +129,11 @@ def _visit_identifier(identifier: TerminalNode):
     return add_span(ast.Identifier(identifier.getText()), get_span(identifier))
 
 
+def _visit_hardware_qubit_identifier(hardware_qubit_identifier: TerminalNode):
+    return add_span(ast.HardwareQubitIdentifier(hardware_qubit_identifier.getText()),
+                    get_span(hardware_qubit_identifier))
+
+
 def _raise_from_context(ctx: ParserRuleContext, message: str):
     raise QASM3ParsingError(f"L{ctx.start.line}:C{ctx.start.column}: {message}")
 
@@ -632,7 +637,7 @@ class QASMNodeVisitor(qasm3ParserVisitor):
                 unit = ast.TimeUnit["dt"]
             return ast.DurationLiteral(value=float(value), unit=unit)
         if ctx.HardwareQubit():
-            return ast.Identifier(ctx.HardwareQubit().getText())
+            return ast.HardwareQubitIdentifier(ctx.HardwareQubit().getText())
         raise _raise_from_context(ctx, "unknown literal type")
 
     @span
@@ -788,7 +793,7 @@ class QASMNodeVisitor(qasm3ParserVisitor):
     @span
     def visitGateOperand(self, ctx: qasm3Parser.GateOperandContext):
         if ctx.HardwareQubit():
-            return ast.Identifier(name=ctx.getText())
+            return ast.HardwareQubitIdentifier(name=ctx.getText())
         return self.visit(ctx.indexedIdentifier())
 
     @span
@@ -861,7 +866,7 @@ class QASMNodeVisitor(qasm3ParserVisitor):
     @span
     def visitDefcalOperand(self, ctx: qasm3Parser.DefcalOperandContext):
         if ctx.HardwareQubit():
-            return ast.Identifier(ctx.HardwareQubit().getText())
+            return ast.HardwareQubitIdentifier(ctx.HardwareQubit().getText())
         return _visit_identifier(ctx.Identifier())
 
     def visitStatementOrScope(

--- a/source/openqasm/openqasm3/printer.py
+++ b/source/openqasm/openqasm3/printer.py
@@ -301,6 +301,9 @@ class Printer(QASMVisitor[PrinterState]):
     def visit_Identifier(self, node: ast.Identifier, context: PrinterState) -> None:
         self.stream.write(node.name)
 
+    def visit_HardwareQubitIdentifier(self, node: ast.HardwareQubitIdentifier, context: PrinterState) -> None:
+        self.stream.write(node.name)
+
     def visit_UnaryExpression(self, node: ast.UnaryExpression, context: PrinterState) -> None:
         self.stream.write(node.op.name)
         if properties.precedence(node) >= properties.precedence(node.expression):

--- a/source/openqasm/openqasm3/properties.py
+++ b/source/openqasm/openqasm3/properties.py
@@ -15,6 +15,7 @@ _PRECEDENCE_TABLE = {
     # Identifiers/literals are the top, since you never need to put brackets
     # around a single literal or identifier.
     ast.Identifier: 14,
+    ast.HardwareQubitIdentifier: 14,
     ast.BitstringLiteral: 14,
     ast.BooleanLiteral: 14,
     ast.DurationLiteral: 14,


### PR DESCRIPTION
#### Before this PR
The ANTLR lexer and ANTLR parser distinguish between two kinds of identifiers with two tokens `Identifier` and `HardwareQubit`.

However before this PR, both of these tokens are merged into a single `ast` node, `ast.Identifier`, in the openqasm3 module. For example:
https://github.com/openqasm/openqasm/blob/7c98e1b2e88a033be247c1edb1926d048f18ffb9/source/openqasm/openqasm3/parser.py#L634-L635

https://github.com/openqasm/openqasm/blob/7c98e1b2e88a033be247c1edb1926d048f18ffb9/source/openqasm/openqasm3/parser.py#L789-L792

https://github.com/openqasm/openqasm/blob/7c98e1b2e88a033be247c1edb1926d048f18ffb9/source/openqasm/openqasm3/parser.py#L862-L865

#### Change introduced by PR

This PR instead associates `qasm3Parser.HardwareQubit` with a new type of node `ast.HardwareQubitIdentifer`. As before `qasm3Parser.Identifier` is associated with `ast.Identifier`.

#### Why

Before this PR, this semantic distinction must be made immediately by any downstream consumer in order to do anything useful. This is done by checking if the property `Identifier.name` begins with the character `$`.

Instead the semantic distinction should be done as early as possible without losing flexibility. 


