### PR TITLE
Added Row Major array representation requirement to types.rst.

### DIFF
--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -743,6 +743,8 @@ the shape and type of the assigned value must match that of the reference.
 Arrays may be passed to subroutines and externs. For more details, see
 :any:`arrays-in-subroutines`.
 
+OpenQASM arrays shall be represented in Row Major order.
+
 Types related to timing
 -----------------------
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Yes.

Are you changing the grammar to adjust to the specification?

Yes.

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

The current OpenQASM3 Spec does not address the in-memory ordering representation of arrays.
This PR adds a one line sentence stating that OpenQASM3 arrays will be stored in Row Major order.



### Details and comments

Storage ordering of (N-Dimensional) arrays has a direct impact on program performance.  There are two ways arrays can be stored in memory: Row Major order and Column Major order:

https://en.wikipedia.org/wiki/Row-_and_column-major_order

Storing arrays in Row Major order provides significant advantages over Column Major order. It enables certain optimizations in the compiler that are not possible in Column Major order.

https://cs.stackexchange.com/questions/71985/row-major-vs-column-major-order-2d-arrays-access-in-programming-languages

https://www.wyzant.com/resources/answers/620254/what-are-the-benefits-of-row-major-order-over-column-major-order-when-proce

For example, Fortran stores arrays in Column Major order. Fortran programs that want to avail themselves of vectorization in `for` loops must convert their 2-dimensional arrays to Row Major order before such optimizations can be applied. This, of course, entails overhead as well, and in some cases makes the vectorization entirely unprofitable -- whatever performance gain may have been achieved by vectorization is canceled out by the overhead of the array transpose.

```
 INTEGER array(2, 3), result(3, 2)
 array = RESHAPE((/1, 2, 3, 4, 5, 6/), (/2, 3/))
 ! array is  1  3  5
 !                 2  4  6
 result = TRANSPOSE(array)
 ! result is 1  2
 !                  3  4
 !                  5  6
 END
```

For the most idiomatic loops generally being written in programs:

```
array[int, 10, 10] ai;
for int i in [0 : 9]  {
    for int j in [0 : 9] {
        // Do something useful with ai[i, j]
    }
}
````

the compiler can take advantage of hardware prefetch, and preload elements of the array in cache, improving performance.




