### PR TITLE
Fixing documentation with respect to array indexing

### DIFF
--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -909,7 +909,9 @@ should be explicitly declared and assigned the concatenation.
    subroutine_call(first ++ third) // forbidden
    subroutine_call(selfConcat) // allowed
 
-Arrays can be sliced just like quantum registers using index sets. Slicing uses
+Arrays can be sliced just like quantum registers using a range ``a:b:c`` 
+and can be indexed using an integer but cannot be indexed by a a comma-separated 
+list of integers contained in braces ``{a,b,c,…}``. Slicing uses
 the subscript operator ``[]``, but produces an array (or reference in the case
 of assignment) with the same number of dimensions as the given identifier.
 Array slicing is syntactic sugar for concisely expressing for loops over


### PR DESCRIPTION
Main issue: #458 

### Summary
The `comma-separated list of integers contained in braces {a,b,c,…}` way of indexing should not be used for arrays are arrays are meant to be only indexed by single integers and sliced by regular (i.e., not arbitrary) indices. 

This was not cleat at all in the documentation. 
This PR tries to fix this shortcoming.

### Details and comments

The current fix is minimal. I feel like the documentation would benefit from a re-writing for this part. I can see two ways:
1. presenting the different methods of indexing (single integer, integer set, slice) first, and then specifying which method is valid for each array-like types.
2. starting by presenting the most restricted type (arrays) and extending them in the next sections by writing something like "ints are considered as arrays of bits" and "registers (quantum or classical) are considered as arrays of (qu)bits with the additional capability of being indexed by integers sets `{a,b,c,…}`.
