### PR TITLE
Add round-trip test for annotation parse/print

### DIFF
--- a/source/openqasm/openqasm3/printer.py
+++ b/source/openqasm/openqasm3/printer.py
@@ -117,7 +117,7 @@ def _maybe_annotated(method):
     @functools.wraps(method)
     def annotated(self: "Printer", node: ast.Statement, context: PrinterState) -> None:
         for annotation in node.annotations:
-            self.visit(annotation)
+            self.visit(annotation, context)
         return method(self, node, context)
 
     return annotated

--- a/source/openqasm/tests/test_printer.py
+++ b/source/openqasm/tests/test_printer.py
@@ -925,3 +925,15 @@ if (i) {
 """.strip()
         output = openqasm3.dumps(openqasm3.parse(input_), indent="  ", chain_else_if=True).strip()
         assert output == input_
+
+    def test_annotations(self):
+        input_ = """
+@ann_1
+int[32] i = 0;
+if (i == 0) {
+  @ann_2
+  i += 1;
+}
+""".strip()
+        output = openqasm3.dumps(openqasm3.parse(input_), indent="  ").strip()
+        assert output == input_


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Annotations were not being printed at the correct indentation level. An easy bugfix since it just required correctly passing the context object. New test assures round-trip parse/print for annotations.