### PR TITLE
Clarify Issue #472 - Physical Qubits cannot be Aliased

### DIFF
--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -58,7 +58,7 @@ Quantum types
 
 Qubits
 ~~~~~~
-
+physical-qubits
 There is a quantum bit (``qubit``) type that is interpreted as a reference to a
 two-level subsystem of a quantum state. The statement ``qubit name;``
 declares a reference to a quantum bit. These qubits are referred
@@ -115,6 +115,8 @@ Qubits cannot be declared within gates or subroutines. This simplifies OpenQASM
 significantly since there is no need for quantum memory management.
 However, it also means that users or compiler have to explicitly manage
 the quantum memory.
+
+.. _physical-qubits:
 
 Physical Qubits
 ~~~~~~~~~~~~~~~
@@ -777,7 +779,7 @@ intent.
 Aliasing
 --------
 
-The ``let`` keyword allows quantum bits and registers to be referred to by
+The ``let`` keyword allows declared quantum bits and registers to be referred to by
 another name as long as the alias is in scope.
 
 .. code-block::
@@ -785,6 +787,8 @@ another name as long as the alias is in scope.
   qubit[5] q;
   // myreg[0] refers to the qubit q[1]
   let myreg = q[1:4];
+
+Note that :ref:`physical qubits <physical-qubits>` are not declared and so cannot be aliased.
 
 Index sets and slicing
 ----------------------

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -58,7 +58,7 @@ Quantum types
 
 Qubits
 ~~~~~~
-physical-qubits
+
 There is a quantum bit (``qubit``) type that is interpreted as a reference to a
 two-level subsystem of a quantum state. The statement ``qubit name;``
 declares a reference to a quantum bit. These qubits are referred


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary
Address #472 by clarifying that physical qubits cannot be aliased


### Details and comments
I have no opinion either way, but the standard _seems_ to indicate that physical qubits are not declared, therefore cannot be aliased. Clarifying the language in the reverse direction is equally acceptable.

