### PR TITLE
Proposed appointment of Erik Davis to the TSC.

### DIFF
--- a/governance.md
+++ b/governance.md
@@ -23,7 +23,7 @@ We will form a **Technical Steering Committee**. The TSC shall be composed of 6 
 * Dor Israeli (Quantum Machines)
 * Lev S Bishop (IBM Quantum)
 * Blake Johnson (IBM Quantum)
-* Steven Heidel (AWS)
+* Erik Davis (AWS)
 * Bettina Heim (Nvidia)
 * Philipp Schindler (Innsbruck)
 
@@ -43,10 +43,12 @@ The responsibility of the TSC **Secretary** include:
 
 The TSC will, from time to time, elect to create **Working Groups** to study issues. The TSC will appoint a **Contributor** as chair for each WG. These WGs should come back to the TSC with a proposal in the form of a language RFC or pull request to the OpenQASM specification. A WG will be automatically disbanded upon acceptance or (final) rejection of an RFC.
 
-**TSC Members** will serve a 2-year term, with the exception of the founding TSC which will have staggered terms to avoid an election of an entire TSC all at once. New **TSC Members** will be selected by nomination of the TSC, followed by a vote which is open to all **Contributors**. Outgoing **TSC Members** participate in the nomination process which selects their successors. Note that **TSC Members** may be re-elected to serve additional 2-year terms. The same process will be used in the event that a **TSC Member** resigns prior to the end of their term.
+**TSC Members** will serve a 2-year term, with the exception of the founding TSC which will have staggered terms to avoid an election of an entire TSC all at once. New **TSC Members** will be selected by nomination of the TSC, followed by a vote which is open to all **Contributors**. Outgoing **TSC Members** participate in the nomination process which selects their successors. Note that **TSC Members** may be re-elected to serve additional 2-year terms. The same process will be used in the event that a **TSC Member** resigns prior to the end of their term. The TSC may also appoint an individual to fulfill the balance of a resigning **TSC Member's** term.
 
 
 ### Past TSCs
+
+* On 2023-06-13, Steven Heidel resigned and the TSC appointed Erik Davis (AWS) to serve the remainder of Steven's term.
 
 * The initial TSC, finishing on 2023-01-13 was:
 


### PR DESCRIPTION
@stevenheidel has announced his resignation from the TSC. After discussion, it was decided that to avoid voter fatigue, it would be better to appointment someone to serve the remaining 5-6 months of Steven's term rather than running a snap election cycle now. This PR both amends the governance doc to give the TSC the authority to make such appointments, and proposed Erik Davis as appointee.