### PR TITLE
Allow identifiers in `measureExpression`

### DIFF
--- a/source/grammar/qasm3Parser.g4
+++ b/source/grammar/qasm3Parser.g4
@@ -155,7 +155,7 @@ expression:
 // not in the expression tree, but can contain elements that are within it.
 aliasExpression: expression (DOUBLE_PLUS expression)*;
 declarationExpression: arrayLiteral | expression | measureExpression;
-measureExpression: MEASURE gateOperand;
+measureExpression: ( MEASURE | Identifier ) gateOperand;
 rangeExpression: expression? COLON expression? (COLON expression)?;
 setExpression: LBRACE expression (COMMA expression)* COMMA? RBRACE;
 arrayLiteral: LBRACE (expression | arrayLiteral) (COMMA (expression | arrayLiteral))* COMMA? RBRACE;

--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -566,6 +566,7 @@ class QuantumMeasurement(QASMNode):
     """
 
     qubit: Union[IndexedIdentifier, Identifier]
+    name: Identifier = field(default_factory=lambda : Identifier("measure"))
 
 
 # Note that this is not a QuantumStatement because it involves access to

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -572,7 +572,10 @@ class QASMNodeVisitor(qasm3ParserVisitor):
     def visitMeasureExpression(self, ctx: qasm3Parser.MeasureExpressionContext):
         if self._in_gate():
             _raise_from_context(ctx, "cannot have a non-unitary 'measure' instruction in a gate")
-        return ast.QuantumMeasurement(qubit=self.visit(ctx.gateOperand()))
+        return ast.QuantumMeasurement(
+            qubit=self.visit(ctx.gateOperand()),
+            name=_visit_identifier(ctx.getChild(0)),
+        )
 
     @span
     def visitDurationofExpression(self, ctx: qasm3Parser.DurationofExpressionContext):

--- a/source/openqasm/openqasm3/printer.py
+++ b/source/openqasm/openqasm3/printer.py
@@ -454,7 +454,7 @@ class Printer(QASMVisitor[PrinterState]):
         self._end_statement(context)
 
     def visit_QuantumMeasurement(self, node: ast.QuantumMeasurement, context: PrinterState) -> None:
-        self.stream.write("measure ")
+        self.stream.write(node.name.name + " ")
         self.visit(node.qubit, context)
 
     @_maybe_annotated

--- a/source/openqasm/tests/test_printer.py
+++ b/source/openqasm/tests/test_printer.py
@@ -450,10 +450,12 @@ measure q;
 measure $0;
 measure q[0];
 measure q[1:3];
+measure_iq q;
 c = measure q;
 c = measure $0;
 c = measure q[0];
 c = measure q[1:3];
+c = measure_iq q;
 def f() {
   return measure q;
 }
@@ -465,6 +467,9 @@ def f() {
 }
 def f() {
   return measure q[1:3];
+}
+def f() {
+  return measure_iq q;
 }
 """.strip()
         output = openqasm3.dumps(

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -1080,6 +1080,40 @@ def test_measurement():
     SpanGuard().visit(program)
 
 
+def test_custom_measurement():
+    p = """
+    measure_iq q;
+    measure_iq q -> c[0];
+    c[0] = measure_iq q[0];
+    """.strip()
+    program = parse(p)
+    assert _remove_spans(program) == Program(
+        statements=[
+            QuantumGate(
+                name=Identifier("measure_iq"),
+                modifiers=[],
+                arguments=[],
+                qubits=[Identifier("q")],
+            ),
+            QuantumMeasurementStatement(
+                measure=QuantumMeasurement(
+                    qubit=Identifier("q"),
+                    name=Identifier("measure_iq"),
+                ),
+                target=IndexedIdentifier(name=Identifier("c"), indices=[[IntegerLiteral(0)]]),
+            ),
+            QuantumMeasurementStatement(
+                measure=QuantumMeasurement(
+                    qubit=IndexedIdentifier(Identifier("q"), indices=[[IntegerLiteral(0)]]),
+                    name=Identifier("measure_iq"),
+                ),
+                target=IndexedIdentifier(name=Identifier("c"), indices=[[IntegerLiteral(0)]]),
+            ),
+        ]
+    )
+    SpanGuard().visit(program)
+
+
 @pytest.mark.parametrize("name", ['"openpulse"', "'openpulse'", '"001"'])
 def test_calibration_grammar_declaration(name):
     p = f"""


### PR DESCRIPTION
### Summary

The current syntax for measurement precludes the usage of defcals with return values, as discussed in this issue: https://github.com/openqasm/openqasm/issues/481

This PR extends `measureExpression` to allow for general identifiers. For example, this supports the following

```
measure_iq q;
measure_iq q -> c[0];
c[0] = measure_iq q[0];
```

### Details and comments

This is the smallest change I could think of to support this functionality. There's one wart, which is that `measure_iq q;` is ambiguous and resolves to a gate application rather than a quantum measurement.