### PR TITLE
Change characterization of duration from positive real to real number

### DIFF
--- a/source/language/delays.rst
+++ b/source/language/delays.rst
@@ -22,7 +22,7 @@ or “implement this gate as late as possible".
 Duration and stretch types
 ---------------------------
 
-The ``duration`` type is used denote increments of time. Durations are positive real numbers
+The ``duration`` type is used denote increments of time. Durations are real numbers
 that are manipulated at compile time. Durations must be followed by time units which can be
 any of the following:
 


### PR DESCRIPTION
Durations may be positive or negative. Most of the documentation on delays reflects this. However, when introducing durations, they are erroneously said to be restricted to positive real numbers. This commit removes the word "positive" in the erroneous sentence.

Fixes #465


