### PR TITLE
Allow pragmas outside of global scope

### DIFF
--- a/source/language/directives.rst
+++ b/source/language/directives.rst
@@ -15,9 +15,10 @@ Pragma directives start with ``pragma`` and continue to the end of line. The
 text after ``pragma`` is a single string, and parsing is left to the specific
 implementation. Implementations may optionally choose to support the older ``#pragma``
 keyword as a custom extension.
-Pragmas should be processed as soon as they are encountered; if a
-pragma is not supported by a compiler pass it should be ignored and preserved
-intact for future passes.  Pragmas should avoid stateful or positional
+
+Pragmas may appear anywhere in the program. Pragmas should be processed as soon as they 
+are encountered; if a pragma is not supported by a compiler pass it should be ignored 
+and preserved intact for future passes.  Pragmas should avoid stateful or positional
 interactions to avoid unexpected behaviors between included source files. If the
 position is relevant to a pragma, an annotation should be used instead.
 

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -215,8 +215,6 @@ class QASMNodeVisitor(qasm3ParserVisitor):
 
     @span
     def visitPragma(self, ctx: qasm3Parser.PragmaContext):
-        if not self._in_global_scope():
-            _raise_from_context(ctx, "pragmas must be global")
         return ast.Pragma(
             command=ctx.RemainingLineContent().getText() if ctx.RemainingLineContent() else None
         )

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -1740,6 +1740,9 @@ def test_pragma():
     pragma command arg1 arg2
     #pragma otherwise_invalid_token 1a2%&
     pragma otherwise_invalid_token 1a2%&
+    {
+      pragma another_command
+    }
     """  # No strip because all line endings are important for pragmas.
     program = parse(p)
     assert _remove_spans(program) == Program(
@@ -1750,6 +1753,7 @@ def test_pragma():
             Pragma(command="command arg1 arg2"),
             Pragma(command="otherwise_invalid_token 1a2%&"),
             Pragma(command="otherwise_invalid_token 1a2%&"),
+            CompoundStatement([Pragma("another_command")]),
         ]
     )
     SpanGuard().visit(program)
@@ -1810,7 +1814,6 @@ class TestFailurePaths:
             ("qubit q;", "qubit declarations must be global"),
             ("qreg q;", "qubit declarations must be global"),
             ("qreg q[5];", "qubit declarations must be global"),
-            ("\npragma command\n", "pragmas must be global"),
         ),
     )
     def test_global_statement_in_nonglobal_context(self, statement, message):


### PR DESCRIPTION
From [the spec on pragma](https://openqasm.com/language/directives.html#pragmas),

> Pragma directives start with pragma and continue to the end of line. The text after pragma is a single string, and parsing is left to the specific implementation. Implementations may optionally choose to support the older #pragma keyword as a custom extension. Pragmas should be processed as soon as they are encountered; if a pragma is not supported by a compiler pass it should be ignored and preserved intact for future passes. Pragmas should avoid stateful or positional interactions to avoid unexpected behaviors between included source files. **If the position is relevant to a pragma, an annotation should be used instead.**

The grammar places no restrictions on where pragmas may appear. However, the Python reference parser currently raises an exception if a pragma occurs outside of the global scope. I do not see the point of this restriction. If the meaning of a pragma is independent of its position, then one could simply allow them anywhere. 

This PR changes the parser to not treat pragmas outside of the global scope as an error. I have added a clarifying line to the spec indicating that this is allowed.

To slightly motivate why I prefer the flexibility of a "pragma anywhere" approach, I will say that we often work with OpenQASM programs which are produced by mechanically combining various AST fragments. If any of these AST fragments includes a pragma, then their composition is not so simple. For example, we may wish to produce a defcal "on-the-fly", and as it stands the restriction on `pragma` placement requires that any pragmas associated with the defcal get percolated to the program toplevel via some side channel. It would be much more convenient to allow defcal bodies to carry pragma statements. To give another example, we sometimes take a sequence of statements and wrap this in a loop (e.g. to scan over a parameter as part of a larger experiment) -- again life is simpler if pragmas don't have to bubble up to the toplevel.