### PR TITLE
Update links and references in the contributing guidelines and license.

### DIFF
--- a/.github/ISSUE_TEMPLATE/spec_proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/spec_proposal.yaml
@@ -1,0 +1,36 @@
+name: 🌻 Spec Proposal
+description: Propose a change to the OpenQASM specification
+title: "[]:"
+labels: ["proposal"]
+body:
+  - type: markdown
+    id: description
+    attributes:
+      label: "Description"
+      placeholder: |
+        Describe the proposed specification change here.
+
+  - type: markdown
+    id: motivation
+    attributes:
+      label: "Motivation"
+      placeholder: |
+        Motivate the proposed change here.
+
+  - type: markdown
+    id: authors
+    attributes:
+      label: "Authors"
+      placeholder: |
+        A list with the names, and optionally the Github handles, of the
+        people involved in the proposal.
+
+  - type: markdown
+    id: examples
+    attributes:
+      label: "Examples"
+      placeholder: |
+        ```text
+        // One or more examples of how to use this proposal in an OpenQASM
+        // program.
+        ```

--- a/.github/ISSUE_TEMPLATE/spec_proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/spec_proposal.yaml
@@ -1,23 +1,23 @@
 name: 🌻 Spec Proposal
 description: Propose a change to the OpenQASM specification
-title: "[]:"
+title: "[proposal]:"
 labels: ["proposal"]
 body:
-  - type: markdown
+  - type: textarea
     id: description
     attributes:
       label: "Description"
       placeholder: |
         Describe the proposed specification change here.
 
-  - type: markdown
+  - type: textarea
     id: motivation
     attributes:
       label: "Motivation"
       placeholder: |
         Motivate the proposed change here.
 
-  - type: markdown
+  - type: textarea
     id: authors
     attributes:
       label: "Authors"
@@ -25,7 +25,7 @@ body:
         A list with the names, and optionally the Github handles, of the
         people involved in the proposal.
 
-  - type: markdown
+  - type: textarea
     id: examples
     attributes:
       label: "Examples"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Please follow the next rules for the commit messages:
 
 - Draft: Backlog items with different levels of abstraction. Anybody can add an issue in the [main repo](https://github.com/openqasm/openqasm). Please label it as `draft`.
 - Proposal: An idea with the correct form:
-  - Add an issue in the [main repo](https://github.com/openqasm/openqasm) labeled as `proposal` using the spec proposal template.
+  - Add an issue in the [main repo](https://github.com/openqasm/openqasm) labeled as `proposal` using [the spec proposal template](https://github.com/openqasm/openqasm/issues/new?template=spec_proposal.yaml)
 - Candidate: During each monthly meeting the assistants select the ones considered more interesting to pass to the next stage. One of the core devs will start commenting on the issue to guide the owner into the next steps, including:
   - Fork [the main repo](https://github.com/openqasm/openqasm).
   - Add the content of the proposal, note that conformance tests are mandatory at this point.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ You can contribute in many ways to this project.
 
 ## Issue reporting
 
-:fire: This is a good point to start, when you find a problem please add it to the [issue tracker](https://github.com/Qiskit/openqasm/issues).
+:fire: This is a good point to start, when you find a problem please add it to the [issue tracker](https://github.com/openqasm/openqasm/issues).
 
 ## Doubts solving
 
@@ -56,19 +56,19 @@ Please follow the next rules for the commit messages:
 ### Pull requests
 
 - We use [GitHub pull requests](https://help.github.com/articles/about-pull-requests) to accept the contributions.
-- Except for proposals (see next point), please, use [pull requests](https://github.com/Qiskit/openqasm/pulls) as is to submit a new one :smile:.
+- Except for proposals (see next point), please, use [pull requests](https://github.com/openqasm/openqasm/pulls) as is to submit a new one :smile:.
 - Review the parts of the documentation regarding the new changes and update it if it's needed.
 - New features often imply changes in the existent tests or new ones are needed. Once they're updated/added please be sure they keep passing.
 
 ## Spec proposals
 
-:bulb: All new ideas go through the next stages to become a new feature of the language.
+:bulb: All new ideas go through the following stages to become a new feature of the language:
 
-- Draft: Backlog items with different levels of abstraction. Anybody can add one issue in the [main repo](https://github.com/Qiskit/openqasm). Please label it as `draft`.
+- Draft: Backlog items with different levels of abstraction. Anybody can add an issue in the [main repo](https://github.com/openqasm/openqasm). Please label it as `draft`.
 - Proposal: An idea with the correct form:
-  - Add one issue in the [main repo](https://github.com/Qiskit/openqasm) labeled as `proposal` using [this template](templates/proposal.md).
+  - Add an issue in the [main repo](https://github.com/openqasm/openqasm) labeled as `proposal` using the spec proposal template.
 - Candidate: During each monthly meeting the assistants select the ones considered more interesting to pass to the next stage. One of the core devs will start commenting on the issue to guide the owner into the next steps, including:
-  - Fork [the main repo](https://github.com/Qiskit/openqasm).
+  - Fork [the main repo](https://github.com/openqasm/openqasm).
   - Add the content of the proposal, note that conformance tests are mandatory at this point.
   - Make a pull request.
   - The core dev can ask for changes before reaching the next stage.
@@ -78,7 +78,7 @@ Please follow the next rules for the commit messages:
 
 The development cycle for OpenQASM is managed in the open using Github for project management.
 TODO: When preparing a new release changes for the released version should be identified
-in the release notes (See [issue #328](https://github.com/Qiskit/openqasm/issues/328)).
+in the release notes (See [issue #328](https://github.com/openqasm/openqasm/issues/328)).
 
 ### Semantic Versioning
 The OpenQASM language uses [semantic versioning (semver)](https://semver.org/).

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021, OpenQASM Contributors
+   Copyright 2017-2023, OpenQASM Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/WG.md
+++ b/WG.md
@@ -74,7 +74,7 @@ Members: Niel de Beaudrap, Hiroshi Horii, Blake Johnson, Colm Ryan, Luciano Bell
 
 ### Dynamic Dereference & Allocation
 
-**Objectives**: Formulate response to issues raised by [Physical mapping of dynamically dereferenced qubits #307](https://github.com/Qiskit/openqasm/issues/307)
+**Objectives**: Formulate response to issues raised by [Physical mapping of dynamically dereferenced qubits #307](https://github.com/openqasm/openqasm/issues/307)
  * Provide concrete examples proving this cannot be dealt with in OpenQASM 3 as the spec stands
  * If in scope, provide rough solutions.
  * Keep in mind the difference between dynamic dereference and dynamic allocation.

--- a/source/grammar/setup.cfg
+++ b/source/grammar/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = openqasm_reference_parser
-url = https://github.com/Qiskit/openqasm
+url = https://github.com/openqasm/openqasm
 author = OpenQASM Contributors
 description = Reference parser for OpenQASM files
 long_description = file: README.md

--- a/source/language/comments.rst
+++ b/source/language/comments.rst
@@ -21,7 +21,7 @@ Version string
 The first non-comment line of an OpenQASM program may optionally be
 ``OPENQASM`` *M.m* ``;`` indicating a major version *M* and minor version *m*.
 More details on versioning and the release cycle for OpenQASM may be found
-`here <https://github.com/Qiskit/openqasm/blob/main/CONTRIBUTING.md>`_.
+`here <https://github.com/openqasm/openqasm/blob/main/CONTRIBUTING.md>`_.
 
 The minor version number, expressed as a decimal point after the major version
 number followed by a number, is optional. If not present, the minor version

--- a/source/language/openpulse.rst
+++ b/source/language/openpulse.rst
@@ -238,7 +238,7 @@ Waveforms
 
 Waveforms are of type ``waveform`` and can either be:
 
-- An array of complex samples (note this syntax is still under [active development](https://github.com/Qiskit/openqasm/pull/301) and is subject to change.) which define the points for the waveform envelope
+- An array of complex samples which define the points for the waveform envelope
 - An abstract mathematical function representing a waveform. This will later be
   materialized into a list of complex samples, either by the compiler or the
   hardware using the parameters provided to the ``extern`` declared waveform template.

--- a/source/openqasm/README.md
+++ b/source/openqasm/README.md
@@ -1,6 +1,6 @@
 # OpenQASM 3 Python Reference
 
-[![License](https://img.shields.io/github/license/Qiskit/openqasm.svg)](https://opensource.org/licenses/Apache-2.0)<!-- long-description-skip-begin -->[![Release](https://img.shields.io/pypi/v/openqasm3)](https://pypi.org/project/openqasm3)<!-- long-description-skip-end -->
+[![License](https://img.shields.io/github/license/openqasm/openqasm.svg)](https://opensource.org/licenses/Apache-2.0)<!-- long-description-skip-begin -->[![Release](https://img.shields.io/pypi/v/openqasm3)](https://pypi.org/project/openqasm3)<!-- long-description-skip-end -->
 
 The `openqasm3` package contains the reference abstract syntax tree (AST) for representing OpenQASM 3 programs, tools to parse text into this AST, and tools to manipulate the AST.
 
@@ -39,7 +39,7 @@ All extras can be installed with the target `openqasm3[all]`.
 
 ## Development Environment
 
-To work on development, you will need to have a complete [ANTLR](https://www.antlr.org/) installation (not just the runtime), and the ANTLR grammar files from the [main OpenQASM repository](https://github.com/Qiskit/openqasm).
+To work on development, you will need to have a complete [ANTLR](https://www.antlr.org/) installation (not just the runtime), and the ANTLR grammar files from the [main OpenQASM repository](https://github.com/openqasm/openqasm).
 
 ### Setting up ANTLR
 

--- a/source/openqasm/docs/contributing.rst
+++ b/source/openqasm/docs/contributing.rst
@@ -3,7 +3,7 @@ Contributing
 ============
 
 We welcome any contributions to make this reference package better and more useful, that stay within the bounds of the :ref:`project goals <project-goals>`.
-An easy way to help us to make bug reports if you find something that doesn't work correctly, by opening an issue on `our GitHub page <https://github.com/Qiskit/openqasm/issues/new>`__.
+An easy way to help us to make bug reports if you find something that doesn't work correctly, by opening an issue on `our GitHub page <https://github.com/openqasm/openqasm/issues/new>`__.
 
 If you want to work with the code to make pull requests to improve it, you will need some further packages.
 
@@ -11,7 +11,7 @@ If you want to work with the code to make pull requests to improve it, you will 
 Development Environment
 =======================
 
-To work on development, you will need to have a complete `ANTLR <https://www.antlr.org/>`__ installation (not just the runtime), and the ANTLR grammar files from the `main OpenQASM repository <https://github.com/Qiskit/openqasm>`__.
+To work on development, you will need to have a complete `ANTLR <https://www.antlr.org/>`__ installation (not just the runtime), and the ANTLR grammar files from the `main OpenQASM repository <https://github.com/openqasm/openqasm>`__.
 
 Setting up ANTLR
 ----------------

--- a/source/openqasm/setup.cfg
+++ b/source/openqasm/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = openqasm3
-url = https://github.com/Qiskit/openqasm
+url = https://github.com/openqasm/openqasm
 author = OpenQASM Contributors
 description = Reference OpenQASM AST in Python
 long_description = file: README.md


### PR DESCRIPTION
### Summary

I've updated the repository links in the contributing guidelines and the copyright years in the license file.

The contributing guidelines referred to a now non-existent template for proposing specification changes, so I added a new template.

Update:

I found a few other places that referenced the old repository so I updated those. Notably:

- I changed the repo URL in `setup.cfg`
- I removed what appears to be an outdated caveat in the OpenPulse specification that referred to a closed issue.

### Details and comments

I think everything is covered above in the summary.

There is a question about what the copyright dates should be. I opted to cover the date range from when the license file was added (which seems a reasonable year for first publication) until now (since each commit essentially publishes the changes).