### PR TITLE
Add implementation of `switch` to ANTLR and reference AST

### DIFF
--- a/source/grammar/qasm3Lexer.g4
+++ b/source/grammar/qasm3Lexer.g4
@@ -33,6 +33,9 @@ RETURN: 'return';
 FOR: 'for';
 WHILE: 'while';
 IN: 'in';
+SWITCH: 'switch';
+CASE: 'case';
+DEFAULT: 'default';
 
 PRAGMA: '#'? 'pragma' -> pushMode(EAT_TO_LINE_END);
 AnnotationKeyword: '@' Identifier ->  pushMode(EAT_TO_LINE_END);

--- a/source/grammar/qasm3Parser.g4
+++ b/source/grammar/qasm3Parser.g4
@@ -43,6 +43,7 @@ statement:
         | quantumDeclarationStatement
         | resetStatement
         | returnStatement
+        | switchStatement
         | whileStatement
     )
 ;
@@ -67,6 +68,11 @@ forStatement: FOR scalarType Identifier IN (setExpression | LBRACKET rangeExpres
 ifStatement: IF LPAREN expression RPAREN if_body=statementOrScope (ELSE else_body=statementOrScope)?;
 returnStatement: RETURN (expression | measureExpression)? SEMICOLON;
 whileStatement: WHILE LPAREN expression RPAREN body=statementOrScope;
+switchStatement: SWITCH LPAREN expression RPAREN LBRACE switchCaseItem* RBRACE;
+switchCaseItem:
+    CASE expressionList scope
+    | DEFAULT scope
+;
 
 // Quantum directive statements.
 barrierStatement: BARRIER gateOperandList? SEMICOLON;

--- a/source/grammar/tests/invalid/statements/switch.qasm
+++ b/source/grammar/tests/invalid/statements/switch.qasm
@@ -3,3 +3,4 @@ switch (i) { x $0 }
 switch (i) { case {} }
 switch (i) { case 1,, {} }
 switch (i) { default 0 {} }
+switch (i) { default, default {} }

--- a/source/grammar/tests/invalid/statements/switch.qasm
+++ b/source/grammar/tests/invalid/statements/switch.qasm
@@ -1,0 +1,5 @@
+switch () {}
+switch (i) { x $0 }
+switch (i) { case {} }
+switch (i) { case 1,, {} }
+switch (i) { default 0 {} }

--- a/source/grammar/tests/reference/control_flow/switch.yaml
+++ b/source/grammar/tests/reference/control_flow/switch.yaml
@@ -1,0 +1,170 @@
+source: |
+  switch (i) {
+    case 0 {
+      x $0;
+    }
+    case 1, 2 {
+      x $0;
+      z $1;
+    }
+    case 3, {
+    }
+    default {
+      cx $0, $1;
+    }
+  }
+  switch (i + j) {
+    default {
+      switch (2 * k) {
+        case 0 {
+          x $0;
+        }
+        default {
+          z $0;
+        }
+      }
+    }
+  }
+reference: |
+  program
+    statementOrScope
+      statement
+        switchStatement
+          switch
+          (
+          expression
+            i
+          )
+          {
+          switchCaseItem
+            case
+            expressionList
+              expression
+                0
+            scope
+              {
+              statementOrScope
+                statement
+                  gateCallStatement
+                    x
+                    gateOperandList
+                      gateOperand
+                        $0
+                    ;
+              }
+          switchCaseItem
+            case
+            expressionList
+              expression
+                1
+              ,
+              expression
+                2
+            scope
+              {
+              statementOrScope
+                statement
+                  gateCallStatement
+                    x
+                    gateOperandList
+                      gateOperand
+                        $0
+                    ;
+              statementOrScope
+                statement
+                  gateCallStatement
+                    z
+                    gateOperandList
+                      gateOperand
+                        $1
+                    ;
+              }
+          switchCaseItem
+            case
+            expressionList
+              expression
+                3
+              ,
+            scope
+              {
+              }
+          switchCaseItem
+            default
+            scope
+              {
+              statementOrScope
+                statement
+                  gateCallStatement
+                    cx
+                    gateOperandList
+                      gateOperand
+                        $0
+                      ,
+                      gateOperand
+                        $1
+                    ;
+              }
+          }
+    statementOrScope
+      statement
+        switchStatement
+          switch
+          (
+          expression
+            expression
+              i
+            +
+            expression
+              j
+          )
+          {
+          switchCaseItem
+            default
+            scope
+              {
+              statementOrScope
+                statement
+                  switchStatement
+                    switch
+                    (
+                    expression
+                      expression
+                        2
+                      *
+                      expression
+                        k
+                    )
+                    {
+                    switchCaseItem
+                      case
+                      expressionList
+                        expression
+                          0
+                      scope
+                        {
+                        statementOrScope
+                          statement
+                            gateCallStatement
+                              x
+                              gateOperandList
+                                gateOperand
+                                  $0
+                              ;
+                        }
+                    switchCaseItem
+                      default
+                      scope
+                        {
+                        statementOrScope
+                          statement
+                            gateCallStatement
+                              z
+                              gateOperandList
+                                gateOperand
+                                  $0
+                              ;
+                        }
+                    }
+              }
+          }
+    <EOF>

--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -11,7 +11,7 @@ The reference abstract syntax tree (AST) for OpenQASM 3 programs.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Union, Dict, Tuple
+from typing import List, Optional, Union, Tuple
 from enum import Enum
 
 __all__ = [

--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -1018,7 +1018,7 @@ class SwitchStatement(Statement):
     """
 
     target: Expression
-    cases: Dict[Tuple[int, ...], CompoundStatement]
+    cases: List[Tuple[List[Expression], CompoundStatement]]
     # Note that `None` is quite different to `[]` in this case; the latter is
     # an explicitly empty body, whereas the absence of a default might mean
     # that the switch is inexhaustive, and a linter might want to complain.

--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -11,7 +11,7 @@ The reference abstract syntax tree (AST) for OpenQASM 3 programs.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict, Tuple
 from enum import Enum
 
 __all__ = [
@@ -87,6 +87,7 @@ __all__ = [
     "SizeOf",
     "Span",
     "Statement",
+    "SwitchStatement",
     "CompoundStatement",
     "StretchType",
     "SubroutineDefinition",
@@ -1002,6 +1003,26 @@ class ForInLoop(Statement):
     identifier: Identifier
     set_declaration: Union[RangeDefinition, DiscreteSet, Expression]
     block: List[Statement]
+
+
+@dataclass
+class SwitchStatement(Statement):
+    """A switch-case statement.
+
+    The literal cases are stored in the `cases` dictionary, in declaration
+    order.  Python's `dict` guarantees (for all supported versions of Python)
+    that the iteration order will be insertion order, so this field *is*
+    ordered.
+
+    The default case, if any, is in the `default` attribute.
+    """
+
+    target: Expression
+    cases: Dict[Tuple[int, ...], CompoundStatement]
+    # Note that `None` is quite different to `[]` in this case; the latter is
+    # an explicitly empty body, whereas the absence of a default might mean
+    # that the switch is inexhaustive, and a linter might want to complain.
+    default: Optional[CompoundStatement]
 
 
 @dataclass

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -541,8 +541,9 @@ class QASMNodeVisitor(qasm3ParserVisitor):
                     # only distinct integers are encountered; we leave that to a later step.
                     values.append(self.visit(expr))
                 cases.append((values, self.visit(case.scope())))
+            elif default is not None:
+                _raise_from_context(case, "multiple 'default' cases")
             else:
-                # Default.
                 default = self.visit(case.scope())
         return ast.SwitchStatement(target=target, cases=cases, default=default)
 

--- a/source/openqasm/openqasm3/printer.py
+++ b/source/openqasm/openqasm3/printer.py
@@ -774,6 +774,40 @@ class Printer(QASMVisitor[PrinterState]):
         self._end_line(context)
 
     @_maybe_annotated
+    def visit_SwitchStatement(self, node: ast.SwitchStatement, context: PrinterState) -> None:
+        self._start_line(context)
+        self.stream.write("switch (")
+        self.visit(node.target, context)
+        self.stream.write(") {")
+        self._end_line(context)
+        with context.increase_scope():
+            for values, block in node.cases.items():
+                self._start_line(context)
+                self.stream.write("case ")
+                self.stream.write(", ".join(str(x) for x in values))
+                self.stream.write(" {")
+                self._end_line(context)
+                with context.increase_scope():
+                    for statement in block.statements:
+                        self.visit(statement, context)
+                self._start_line(context)
+                self.stream.write("}")
+                self._end_line(context)
+            if node.default is not None:
+                self._start_line(context)
+                self.stream.write("default {")
+                self._end_line(context)
+                with context.increase_scope():
+                    for statement in node.default.statements:
+                        self.visit(statement, context)
+                self._start_line(context)
+                self.stream.write("}")
+                self._end_line(context)
+        self._start_line(context)
+        self.stream.write("}")
+        self._end_line(context)
+
+    @_maybe_annotated
     def visit_DelayInstruction(self, node: ast.DelayInstruction, context: PrinterState) -> None:
         self._start_line(context)
         self.stream.write("delay[")

--- a/source/openqasm/openqasm3/printer.py
+++ b/source/openqasm/openqasm3/printer.py
@@ -781,10 +781,10 @@ class Printer(QASMVisitor[PrinterState]):
         self.stream.write(") {")
         self._end_line(context)
         with context.increase_scope():
-            for values, block in node.cases.items():
+            for values, block in node.cases:
                 self._start_line(context)
                 self.stream.write("case ")
-                self.stream.write(", ".join(str(x) for x in values))
+                self._visit_sequence(values, context, separator=", ")
                 self.stream.write(" {")
                 self._end_line(context)
                 with context.increase_scope():

--- a/source/openqasm/tests/test_printer.py
+++ b/source/openqasm/tests/test_printer.py
@@ -427,6 +427,35 @@ if (i == 0) {
         output = openqasm3.dumps(openqasm3.parse(input_), indent="  ").strip()
         assert output == input_
 
+    def test_switch_case(self):
+        input_ = """
+switch (i) {
+  case 0 {
+    x $0;
+  }
+  case 1, 2 {
+  }
+  default {
+    z $0;
+  }
+}
+""".strip()
+        output = openqasm3.dumps(openqasm3.parse(input_), indent="  ").strip()
+        assert output == input_
+
+    def test_switch_no_default(self):
+        input_ = """
+switch (i + 1) {
+  case 0 {
+    x $0;
+  }
+  case 1, 2 {
+  }
+}
+""".strip()
+        output = openqasm3.dumps(openqasm3.parse(input_), indent="  ").strip()
+        assert output == input_
+
     def test_jumps(self):
         input_ = """
 while (true) {

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -1555,6 +1555,20 @@ switch (5) {
     with pytest.raises(QASM3ParsingError, match="'case' statement after 'default'"):
         parse(program)
 
+def test_switch_rejects_multiple_default():
+    program = """
+switch (5) {
+    case 0 {
+    }
+    default {
+    }
+    default {
+    }
+}
+"""
+    with pytest.raises(QASM3ParsingError, match="multiple 'default' cases"):
+        parse(program)
+
 
 def test_delay_instruction():
     p = """

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -1555,6 +1555,7 @@ switch (5) {
     with pytest.raises(QASM3ParsingError, match="'case' statement after 'default'"):
         parse(program)
 
+
 def test_switch_rejects_multiple_default():
     program = """
 switch (5) {


### PR DESCRIPTION
### Summary

This adds a simple implementation in both ANTLR and the Python reference AST (and parser) of the `switch` statement proposed by gh-463.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Details and comments

This is an implementation of, as I understand things, gh-463 with the addition of "Option 2" from Lev's comment: https://github.com/openqasm/openqasm/pull/463#issuecomment-1542344379.

Notably, this only allows one `case` per block with multiple values distinguished by commas, no colon after the values, and the braces are required.  I'm happy to update this PR if any of those fairly minor syntactic items change or I misunderstood the intent.
