### PR TITLE
Consistent whitespace before duration units and imaginary literal.

### DIFF
--- a/source/grammar/qasm3Lexer.g4
+++ b/source/grammar/qasm3Lexer.g4
@@ -123,7 +123,7 @@ ComparisonOperator: '>' | '<' | '>=' | '<=';
 BitshiftOperator: '>>' | '<<';
 
 IMAG: 'im';
-ImaginaryLiteral: (DecimalIntegerLiteral | FloatLiteral) ' '* IMAG;
+ImaginaryLiteral: (DecimalIntegerLiteral | FloatLiteral) [ \t]* IMAG;
 
 BinaryIntegerLiteral: ('0b' | '0B') ([01] '_'?)* [01];
 OctalIntegerLiteral: '0o' ([0-7] '_'?)* [0-7];

--- a/source/grammar/qasm3Lexer.g4
+++ b/source/grammar/qasm3Lexer.g4
@@ -149,7 +149,7 @@ FloatLiteral:
 
 fragment TimeUnit: 'dt' | 'ns' | 'us' | 'µs' | 'ms' | 's';
 // represents explicit time value in SI or backend units
-TimingLiteral: (DecimalIntegerLiteral | FloatLiteral) TimeUnit;
+TimingLiteral: (DecimalIntegerLiteral | FloatLiteral) [ \t]* TimeUnit;
 
 BitstringLiteral: '"' ([01] '_'?)* [01] '"';
 

--- a/source/grammar/tests/reference/declaration/complex.yaml
+++ b/source/grammar/tests/reference/declaration/complex.yaml
@@ -1,9 +1,12 @@
 # indent w/ 2 spaces
+# beware the tab character in f = 1 im below
 source: |
   complex[float] a;
   complex[float] b = 4 - 5.5im;
   complex[float[64]] d = a + 3 im;
   complex[float[32]] c = a ** b;
+  complex[float] e = 1im;
+  complex[float] f = 1	im;
   complex z;
 reference: |
   program
@@ -84,6 +87,36 @@ reference: |
               **
               expression
                 b
+          ;
+    statementOrScope
+      statement
+        classicalDeclarationStatement
+          scalarType
+            complex
+            [
+            scalarType
+              float
+            ]
+          e
+          =
+          declarationExpression
+            expression
+              1im
+          ;
+    statementOrScope
+      statement
+        classicalDeclarationStatement
+          scalarType
+            complex
+            [
+            scalarType
+              float
+            ]
+          f
+          =
+          declarationExpression
+            expression
+              1	im
           ;
     statementOrScope
       statement

--- a/source/grammar/tests/reference/declaration/declaration.yaml
+++ b/source/grammar/tests/reference/declaration/declaration.yaml
@@ -1,4 +1,5 @@
 # indent w/ 2 spaces
+# beware the tab character in dur4 = 8 ns below
 source: |
   int[10] x;
   int[10] y;
@@ -21,6 +22,9 @@ source: |
   float[32] f = .1e+3;
   duration dur = 1000dt;
   duration dur2 = dur + 200ns;
+  duration dur3 = 10 ms;
+  duration dur4 = 8	us;
+  duration dur5 = 1s;
   stretch s;
 reference: |
   program
@@ -310,6 +314,39 @@ reference: |
               +
               expression
                 200ns
+          ;
+    statementOrScope
+      statement
+        classicalDeclarationStatement
+          scalarType
+            duration
+          dur3
+          =
+          declarationExpression
+            expression
+              10 ms
+          ;
+    statementOrScope
+      statement
+        classicalDeclarationStatement
+          scalarType
+            duration
+          dur4
+          =
+          declarationExpression
+            expression
+              8	us
+          ;
+    statementOrScope
+      statement
+        classicalDeclarationStatement
+          scalarType
+            duration
+          dur5
+          =
+          declarationExpression
+            expression
+              1s
           ;
     statementOrScope
       statement

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -297,9 +297,9 @@ designator ``[size]`` can be omitted to use the default hardware ``float``, and
 ``complex`` with no arguments is a synonym for ``complex[float]``.
 
 Imaginary literals are written as a decimal-integer or floating-point literal
-followed by the letters ``im``.  There may be zero or more spaces between the
-numeric component and the ``im`` component.  The type of this token is
-``complex`` (its value has zero real component), and the component type is as
+followed by the letters ``im``.  There may be zero or more spaces or tabs
+between the numeric component and the ``im`` component.  The type of this token
+is ``complex`` (its value has zero real component), and the component type is as
 normal given the floating-point literal, or the machine-size ``float`` if the
 numeric component is an integer.
 


### PR DESCRIPTION
### Summary

This PR makes two small adjustments to whitespace lexing, one for duration units and the other for imaginary literals.

#### Duration units whitespace

For duration units, the language specification currently [reads](https://openqasm.com/language/delays.html#duration-and-stretch-types):

> Units can appear attached to the numerical value, or immediately following separated only by blanks or tabs. 1000ms is the same as 1000 ms.

But this whitespace was not actually supported by the lexer.

This PR adds this support to match the specification.

#### Imaginary literal whitespace

For imaginary literals, the language specification currently [reads](https://openqasm.com/language/types.html#complex-numbers):

> Imaginary literals are written as a decimal-integer or floating-point literal followed by the letters im. There may be zero or more spaces between the numeric component and the im component.

This is correctly implemented, but it seems inconsistent to only allows spaces here and not tabs. Tabs and spaces are both allowed for units and generally wherever whitespace is allowed.

This PR updates the specification and the lexer to allow tabs in this case too.

### Details and comments

The changes to the lexer appear straightforward. Adding tabs to the YAML reference files required the unfortunate use of literal tab characters, but the other options (double quoted YAML blocks) looked worse.