### PR TITLE
Add visitor for `CompoundStatement` and unify visitation of `Statement` lists

### DIFF
--- a/source/openqasm/openqasm3/printer.py
+++ b/source/openqasm/openqasm3/printer.py
@@ -219,7 +219,7 @@ class Printer(QASMVisitor[PrinterState]):
         self._end_statement(context)
 
     def _visit_statement_list(
-        self, nodes: list[ast.Statement], context: PrinterState, prefix: str = " "
+        self, nodes: list[ast.Statement], context: PrinterState, prefix: str = ""
     ) -> None:
         self.stream.write(prefix)
         self.stream.write("{")
@@ -296,7 +296,7 @@ class Printer(QASMVisitor[PrinterState]):
             self._visit_sequence(node.arguments, context, start="(", end=")", separator=", ")
         self.stream.write(" ")
         self._visit_sequence(node.qubits, context, separator=", ")
-        self._visit_statement_list(node.body, context)
+        self._visit_statement_list(node.body, context, prefix=" ")
         self._end_line(context)
 
     @_maybe_annotated
@@ -669,7 +669,7 @@ class Printer(QASMVisitor[PrinterState]):
         if node.return_type is not None:
             self.stream.write(" -> ")
             self.visit(node.return_type, context)
-        self._visit_statement_list(node.body, context)
+        self._visit_statement_list(node.body, context, prefix=" ")
         self._end_line(context)
 
     def visit_QuantumArgument(self, node: ast.QuantumArgument, context: PrinterState) -> None:
@@ -708,7 +708,7 @@ class Printer(QASMVisitor[PrinterState]):
         self.stream.write("if (")
         self.visit(node.condition, context)
         self.stream.write(")")
-        self._visit_statement_list(node.if_block, context)
+        self._visit_statement_list(node.if_block, context, prefix=" ")
         if node.else_block:
             self.stream.write(" else ")
             # Special handling to flatten a perfectly nested structure of
@@ -726,7 +726,7 @@ class Printer(QASMVisitor[PrinterState]):
                 self.visit(node.else_block[0], context)
                 # Don't end the line, because the outer-most `if` block will.
             else:
-                self._visit_statement_list(node.else_block, context, prefix="")
+                self._visit_statement_list(node.else_block, context)
                 self._end_line(context)
         else:
             self._end_line(context)
@@ -737,7 +737,7 @@ class Printer(QASMVisitor[PrinterState]):
         self.stream.write("while (")
         self.visit(node.while_condition, context)
         self.stream.write(")")
-        self._visit_statement_list(node.block, context)
+        self._visit_statement_list(node.block, context, prefix=" ")
         self._end_line(context)
 
     @_maybe_annotated
@@ -754,7 +754,7 @@ class Printer(QASMVisitor[PrinterState]):
             self.stream.write("]")
         else:
             self.visit(node.set_declaration, context)
-        self._visit_statement_list(node.block, context)
+        self._visit_statement_list(node.block, context, prefix=" ")
         self._end_line(context)
 
     @_maybe_annotated
@@ -776,7 +776,7 @@ class Printer(QASMVisitor[PrinterState]):
             self.stream.write("[")
             self.visit(node.duration, context)
             self.stream.write("]")
-        self._visit_statement_list(node.body, context)
+        self._visit_statement_list(node.body, context, prefix=" ")
         self._end_line(context)
 
     def visit_DurationOf(self, node: ast.DurationOf, context: PrinterState) -> None:

--- a/source/openqasm/openqasm3/printer.py
+++ b/source/openqasm/openqasm3/printer.py
@@ -58,7 +58,7 @@ import dataclasses
 import io
 import functools
 
-from typing import Sequence, Optional
+from typing import List, Optional, Sequence
 
 from . import ast, properties
 from .visitor import QASMVisitor
@@ -219,7 +219,7 @@ class Printer(QASMVisitor[PrinterState]):
         self._end_statement(context)
 
     def _visit_statement_list(
-        self, nodes: list[ast.Statement], context: PrinterState, prefix: str = ""
+        self, nodes: List[ast.Statement], context: PrinterState, prefix: str = ""
     ) -> None:
         self.stream.write(prefix)
         self.stream.write("{")

--- a/source/openqasm/openqasm3/printer.py
+++ b/source/openqasm/openqasm3/printer.py
@@ -219,10 +219,9 @@ class Printer(QASMVisitor[PrinterState]):
         self._end_statement(context)
 
     def _visit_statement_list(
-        self, nodes: list[ast.Statement], context: PrinterState, starts_with_space: bool = True
+        self, nodes: list[ast.Statement], context: PrinterState, prefix: str = " "
     ) -> None:
-        if starts_with_space:
-            self.stream.write(" ")
+        self.stream.write(prefix)
         self.stream.write("{")
         self._end_line(context)
         with context.increase_scope():
@@ -256,6 +255,7 @@ class Printer(QASMVisitor[PrinterState]):
         for statement in node.statements:
             self.visit(statement, context)
 
+    @_maybe_annotated
     def visit_CompoundStatement(self, node: ast.CompoundStatement, context: PrinterState) -> None:
         self._start_line(context)
         self._visit_statement_list(node.statements, context)
@@ -726,7 +726,7 @@ class Printer(QASMVisitor[PrinterState]):
                 self.visit(node.else_block[0], context)
                 # Don't end the line, because the outer-most `if` block will.
             else:
-                self._visit_statement_list(node.else_block, context, starts_with_space=False)
+                self._visit_statement_list(node.else_block, context, prefix="")
                 self._end_line(context)
         else:
             self._end_line(context)
@@ -784,7 +784,7 @@ class Printer(QASMVisitor[PrinterState]):
         if isinstance(node.target, ast.QASMNode):
             self.visit(node.target, context)
         else:
-            self._visit_statement_list(node.target, context, starts_with_space=False)
+            self._visit_statement_list(node.target, context, prefix="")
         self.stream.write(")")
 
     def visit_SizeOf(self, node: ast.SizeOf, context: PrinterState) -> None:

--- a/source/openqasm/tests/test_printer.py
+++ b/source/openqasm/tests/test_printer.py
@@ -1,8 +1,7 @@
 import dataclasses
 
-import pytest
-
 import openqasm3
+import pytest
 from openqasm3 import ast
 
 
@@ -937,3 +936,27 @@ if (i == 0) {
 """.strip()
         output = openqasm3.dumps(openqasm3.parse(input_), indent="  ").strip()
         assert output == input_
+
+
+def test_CompoundStatement():
+    # This test can be replaced with a round trip test once something that
+    # parses to a CompoundStatement is implemented (e.g. jakelishman's implementation
+    # of the switch statement #492
+    program = ast.Program(
+        statements=[
+            ast.CompoundStatement(
+                statements=[
+                    ast.ExpressionStatement(ast.IntegerLiteral(value=1)),
+                    ast.ExpressionStatement(ast.IntegerLiteral(value=2)),
+                ]
+            )
+        ]
+    )
+    expected = """
+{
+  1;
+  2;
+}
+    """.strip()
+    output = openqasm3.dumps(program).strip()
+    assert output == expected

--- a/source/openqasm/tests/test_printer.py
+++ b/source/openqasm/tests/test_printer.py
@@ -1,7 +1,8 @@
 import dataclasses
 
-import openqasm3
 import pytest
+
+import openqasm3
 from openqasm3 import ast
 
 

--- a/source/openqasm/tests/test_printer.py
+++ b/source/openqasm/tests/test_printer.py
@@ -942,18 +942,18 @@ def test_CompoundStatement():
     # This test can be replaced with a round trip test once something that
     # parses to a CompoundStatement is implemented (e.g. jakelishman's implementation
     # of the switch statement #492
-    program = ast.Program(
+    cmpnd_stmt = ast.CompoundStatement(
         statements=[
-            ast.CompoundStatement(
-                statements=[
-                    ast.ExpressionStatement(ast.IntegerLiteral(value=1)),
-                    ast.ExpressionStatement(ast.IntegerLiteral(value=2)),
-                ]
-            )
+            ast.ExpressionStatement(ast.IntegerLiteral(value=1)),
+            ast.ExpressionStatement(ast.IntegerLiteral(value=2)),
         ]
     )
+    cmpnd_stmt.annotations = [ast.Annotation(keyword="test_annotation")]
+    program = ast.Program(statements=[cmpnd_stmt])
+
     expected = """
-{
+@test_annotation
+ {
   1;
   2;
 }

--- a/source/openqasm/tests/test_printer.py
+++ b/source/openqasm/tests/test_printer.py
@@ -953,7 +953,7 @@ def test_CompoundStatement():
 
     expected = """
 @test_annotation
- {
+{
   1;
   2;
 }


### PR DESCRIPTION

### Summary

This adds a visitor for `CompoundStatement`'s to the printer by implementing a method for visiting lists of statements to the printer and uses it as appropriate. 

### Details and comments

While reading over [gh-492](https://github.com/openqasm/openqasm/pull/492), which uses `CompoundStatement` to express the statement block for each `case` in `switch` statements, I realized that a printer visitor for `CompoundStatement` (introduced in [gh-487](https://github.com/openqasm/openqasm/pull/487)) hadn't been implemented.

This PR implements that visitor and a method for visiting generic lists of statements during the printing process. Code duplication in the printer is reduced by using this method, where appropriate, throughout the printer.

This PR makes no changes to the grammar nor documentation, only some implementations of the printer, all behavior remains unchanged (as far as I can tell).  

