### PR TITLE
Issue #486: Clarify interpretation of physical qubits

### DIFF
--- a/releasenotes/notes/clarify-physical-qubits-f720f21a3d792c70.yaml
+++ b/releasenotes/notes/clarify-physical-qubits-f720f21a3d792c70.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    Improve physical qubit documentation. Define what constitutes a valid
+    physical identifier, define physical circuits, and answer several questions
+    about what a compiler may do with physical qubits.

--- a/releasenotes/notes/clarify-physical-qubits-f720f21a3d792c70.yaml
+++ b/releasenotes/notes/clarify-physical-qubits-f720f21a3d792c70.yaml
@@ -2,5 +2,5 @@
 upgrade:
   - |
     Improve physical qubit documentation. Define what constitutes a valid
-    physical identifier, define physical circuits, and answer several questions
-    about what a compiler may do with physical qubits.
+    physical identifier, define physical circuits, and specify what
+    an implementer may do with physical qubits.

--- a/source/language/gates.rst
+++ b/source/language/gates.rst
@@ -75,6 +75,8 @@ There are 3 mechanisms to construct new gates:
 
 The next subsections go through these cases.
 
+.. _gate-statement:
+
 Hierarchical gates definitions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -142,16 +142,16 @@ non-consecutive, depending on the device.
 Like virtual qubits, physical qubits are global variables, but unlike virtual qubits, they must
 not be declared.
 
-These qubit types are often used for ``defcal`` blocks because calibrations are typically valid
-only for a particular set of physical qubits (see also :ref:`pulse gates <pulse-gates>`).
+These qubit types are always used for ``defcal`` blocks. Calibrations are valid only for a
+particular set of physical qubits. See also :ref:`pulse gates <pulse-gates>`.
 
-.. TODO: Where is a better place for physical circuit discussion?
-.. TODO: Should we introduce executable circuit as another term for physical circuit?
+Physical qubits cannot be used in ``gate`` statements. See also
+:ref:`gate definitions <gate-statement>`.
 
 Physical qubits are also used in lower parts of the compilation stack when emitting physical
 circuits. A physical circuit is one which only references physical qubits, and every operation
-used in the circuit has an associated ``defcal``, which we can call hardware-native gates or
-measurements. A physical circuit can be directly executed on the target hardware.
+used in the circuit has an associated ``defcal``, which we refer to as hardware-native gates and
+measurements.
 
 .. code-block::
 
@@ -162,7 +162,6 @@ measurements. A physical circuit can be directly executed on the target hardware
 
 Physical qubit constraints
 ..........................
-.. TODO: Can physical qubits be used in a ``defgate``? My answer would be no.
 
 Physical qubits, by definition, reference particular hardware qubits. Circuit equivalence does not
 hold over permutations of physical qubit labels. Thus, physical qubits cannot be remapped by a
@@ -173,9 +172,10 @@ that would require routing or gate decomposition to run (i.e., does not have a `
 operation in the circuit) would by definition not be a physical circuit. However, physical qubits
 can still be used in such circuits.
 
-For example, a program defines the ``H`` gate with the ``gate`` statement. ``H`` is therefore a
-supported gate, but not a hardware-native gate. The compiler can decompose the statement ``H $0;``
-to hardware-native gates, while still respecting strict qubit mapping.
+For example, a program defines the ``H`` gate with the ``gate`` statement, without a corresponding
+``defcal`` of ``H``. ``H`` is therefore a supported gate, but not a hardware-native gate. The
+compiler can decompose the statement ``H $0;`` to hardware-native gates, while still respecting
+strict qubit mapping.
 
 It is possible to write a partially-constrained program with both physical and virtual qubits.
 Such programs are also non-physical circuits, and may or may not be supported by compilers or

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -142,8 +142,8 @@ non-consecutive, depending on the device.
 Like virtual qubits, physical qubits are global variables, but unlike virtual qubits, they must
 not be declared.
 
-These qubit types are often used for ``defcal``s because calibrations are typically valid only
-for a particular set of physical qubits (see also :ref:`pulse gates <pulse-gates>`).
+These qubit types are often used for ``defcal`` blocks because calibrations are typically valid
+only for a particular set of physical qubits (see also :ref:`pulse gates <pulse-gates>`).
 
 .. TODO: Where is a better place for physical circuit discussion?
 .. TODO: Should we introduce executable circuit as another term for physical circuit?

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -164,7 +164,7 @@ Physical qubit constraints
 ..........................
 
 Physical qubits, by definition, reference particular hardware qubits. Circuit equivalence does not
-hold over permutations of physical qubit labels. Thus, physical qubits cannot be remapped by a
+hold over permutations of physical qubit labels. Thus, physical qubits should not be remapped by a
 compiler or hardware provider without opt-in from the programmer.
 
 Note that while physical circuits require physical qubits, the converse need not be true. A circuit


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Adds clarifications about physical qubits, and closes #486

### Details and comments

 - Separates virtual and physical qubit examples
 - Relaxes the consecutive numbering constraint
 - Adds definition for physical circuit: one where every circuit operation has a defcal
 - Physical qubits can be seen as a "no remap" directive (or else they would be virtual qubits)
 - Physical qubits can be used outside of physical circuits

Open questions
 - ~Is there a better place for physical circuit discussion? And is the physical circuit text sufficient as is, or should "executable circuit" be introduced as another term for physical circuit?~
 - ~Can physical qubits be used in a defgate?~

See more discussion on #486 


