### PR TITLE
Update Python versions and dependencies in AST GitHub Actions

### DIFF
--- a/.github/workflows/tests-ast.yml
+++ b/.github/workflows/tests-ast.yml
@@ -15,18 +15,18 @@ jobs:
       fail-fast: false
       matrix:
         # Just using minimum and maximum to avoid exploding the matrix.
-        python-version: ['3.7', '3.10']
+        python-version: ['3.7', '3.12']
         antlr-version: ['4.7', '4.13']
     defaults:
       run:
         working-directory: source/openqasm
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -43,12 +43,6 @@ jobs:
           pip install 'antlr4_python3_runtime==${{ matrix.antlr-version }}'
           pip install "$(echo openqasm3-*.whl)[all]"
 
-      - name: Check format
-        run: black --check --diff openqasm3 tests
-
-      - name: Check style
-        run: pylint openqasm3 tests
-
       - name: Run tests
         run: |
           # Swap into the testing directory so the imported `openqasm3` is the
@@ -58,8 +52,35 @@ jobs:
           cd tests
           pytest -vv --color=yes --import-mode=importlib .
 
+  style:
+    name: Check AST style
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: source/openqasm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Prepare environment
+        run: |
+          set -e
+          python -m pip install --upgrade pip wheel
+          python -m pip install -r requirements-dev.txt
+
+      - name: Check formatting
+        run: black --check --diff openqasm3 tests
+
+      - name: Check lint
+        run: pylint openqasm3 tests
+
   docs:
-    name: Documentation build
+    name: AST documentation build
     needs: build
     runs-on: ubuntu-latest
     defaults:
@@ -67,9 +88,9 @@ jobs:
         working-directory: source/openqasm
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/source/openqasm/pyproject.toml
+++ b/source/openqasm/pyproject.toml
@@ -3,4 +3,4 @@ requires = ["setuptools", "wheel"]
 
 [tool.black]
 line-length = 100
-target-version = ["py36"]
+target-version = ["py37", "py38", "py39", "py310", "py311", "py312"]

--- a/source/openqasm/requirements-dev.txt
+++ b/source/openqasm/requirements-dev.txt
@@ -1,5 +1,8 @@
 pytest>=6.0
 pyyaml
 pylint>=2.9
-black>=20.8b0
 Sphinx>=4.0
+
+# Black uses calver majors for changes to the default style;
+# we can allow updates within a given year.
+black~=23.1


### PR DESCRIPTION
### Summary

This normalise the AST action to only run the style and lint checks once, on the newest Python version, so that differences between the linters and formatters that might arise from bugfixes not backported to the last supported package version for the oldest Python do not cause spurious failures between the two branches.  This notably happened with `black`, where the latest version compatible with Python 3.7 did not contain a bugfix that later versions did have access to.

Further, this updates the latest supported version of Python to 3.12, which matches reality, since previously we had left it at 3.10.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->


### Details and comments


