### PR TITLE
Reno: only require release notes in changes to `source` directory

### DIFF
--- a/.github/renos_updated.sh
+++ b/.github/renos_updated.sh
@@ -3,8 +3,15 @@
 
 git fetch origin main
 
-CHANGED_FILES=$(git diff --name-only origin/main $GITHUB_SHA)
-for file in $CHANGED_FILES
+# We only require release notes for changes in the `source` directory.
+# Other stuff (governance info, github actions, etc) can be ignored.
+CHANGED_SOURCE_FILES=$(git diff --name-only origin/main $GITHUB_SHA -- source)
+if [ -z $CHANGED_SOURCE_FILES ]; then
+    echo "No changes to `source` detected"
+    exit 0;
+fi;
+
+for file in $CHANGED_SOURCE_FILES
 do
    root=$(echo "./$file" | cut -d / -f 3 )
    if [ "$root" = "notes" ]; then

--- a/source/release_notes.rst
+++ b/source/release_notes.rst
@@ -1,1 +1,1 @@
-.. release-notes:: Release Notes (modified)
+.. release-notes:: Release Notes

--- a/source/release_notes.rst
+++ b/source/release_notes.rst
@@ -1,1 +1,1 @@
-.. release-notes:: Release Notes
+.. release-notes:: Release Notes (modified)


### PR DESCRIPTION
### Summary

In https://github.com/openqasm/openqasm/pull/506 we started using Reno for managing release notes. Along with this is check that notes are provided when there is a `git diff`. This PR tweaks that to only check for changes to the `source` directory (i.e. changes to the spec or parser & reference AST). My reasoning is that we do not need to provide release notes for changes to things like GitHub actions, project README, etc, so this check should make an effort to ignore such changes.


