### PR TITLE
Remove reserved keywords

### DIFF
--- a/.github/renos_updated.sh
+++ b/.github/renos_updated.sh
@@ -11,7 +11,8 @@ if [ -z $CHANGED_SOURCE_FILES ]; then
     exit 0;
 fi;
 
-for file in $CHANGED_SOURCE_FILES
+CHANGED_RELEASE_NOTES=$(git diff --name-only origin/main $GITHUB_SHA -- releasenotes)
+for file in $CHANGED_RELEASE_NOTES
 do
    root=$(echo "./$file" | cut -d / -f 3 )
    if [ "$root" = "notes" ]; then

--- a/releasenotes/notes/remove-reserved-switch-keywords-df5ea30f6e775f22.yaml
+++ b/releasenotes/notes/remove-reserved-switch-keywords-df5ea30f6e775f22.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    The keywords ``switch``, ``case``, and ``default`` are no longer reserved
+    by the spec for future expansion of the language.

--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -661,12 +661,6 @@ quantum computations. That is, invoking an ``extern`` function will  *schedule* 
 computation, but does not wait for that computation to terminate.
 
 
-Further reserved keywords
--------------------------
-
-The keywords ``switch``, ``case`` and ``default`` are reserved for future
-expansion of the language.  These words are not valid identifiers.
-
 .. [1]
    ``popcount`` computes the Hamming weight of the input register.
 


### PR DESCRIPTION
This removes the subsection on reserved keywords. With the inclusion of the `switch` statement, we no longer have any keywords reserved which are not already in use by the language.


