### PR TITLE
Add supported_versions to openqasm3.spec.

### DIFF
--- a/releasenotes/notes/add-supported-spec-versions-to-openqasm3-pkg-7ea92eb1181bf0fd.yaml
+++ b/releasenotes/notes/add-supported-spec-versions-to-openqasm3-pkg-7ea92eb1181bf0fd.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Added `openqasm3.spec.supported_versions` which lists the OpenQASM specification
+    versions supported by the `openqasm3` package. Currently the supported versions
+    are 3.0 and 3.1. In future, additional information on the supported specifications
+    may be added to `openqasm3.spec`.

--- a/source/openqasm/docs/api/index.rst
+++ b/source/openqasm/docs/api/index.rst
@@ -12,4 +12,5 @@ In addition, a reference parser to this AST is provided in its simplest form by 
    ast.rst
    parser.rst
    printer.rst
+   spec.rst
    visitor.rst

--- a/source/openqasm/docs/api/spec.rst
+++ b/source/openqasm/docs/api/spec.rst
@@ -1,0 +1,1 @@
+.. automodule:: openqasm3.spec

--- a/source/openqasm/openqasm3/__init__.py
+++ b/source/openqasm/openqasm3/__init__.py
@@ -18,6 +18,7 @@ __all__ = [
     "ast",
     "visitor",
     "properties",
+    "spec",
     "dump",
     "dumps",
     "parser",
@@ -26,7 +27,7 @@ __all__ = [
 
 __version__ = "0.5.0"
 
-from . import ast, visitor, properties
+from . import ast, visitor, properties, spec
 
 from .printer import dump, dumps
 

--- a/source/openqasm/openqasm3/__init__.py
+++ b/source/openqasm/openqasm3/__init__.py
@@ -14,6 +14,16 @@ With the ``[parser]`` extra installed, the simplest interface to the parser is
 the :obj:`~parser.parse` function.
 """
 
+__all__ = [
+    "ast",
+    "visitor",
+    "properties",
+    "dump",
+    "dumps",
+    "parser",
+    "parse",
+]
+
 __version__ = "0.5.0"
 
 from . import ast, visitor, properties
@@ -27,5 +37,6 @@ except ModuleNotFoundError:
     pass
 else:
     # Any import errors in section are of interest to the user, and should be propagated.
+    del antlr4
     from . import parser
     from .parser import parse

--- a/source/openqasm/openqasm3/spec.py
+++ b/source/openqasm/openqasm3/spec.py
@@ -6,8 +6,9 @@ Supported Specification Metadata (``openqasm3.spec``)
 .. currentmodule:: openqasm3.spec
 
 Metadata on the specifications supported by this package.
-"""
 
+.. autodata:: supported_versions
+"""
 
 __all__ = ["supported_versions"]
 

--- a/source/openqasm/openqasm3/spec.py
+++ b/source/openqasm/openqasm3/spec.py
@@ -1,0 +1,19 @@
+"""
+=====================================================
+Supported Specification Metadata (``openqasm3.spec``)
+=====================================================
+
+.. currentmodule:: openqasm3.spec
+
+Metadata on the specifications supported by this package.
+"""
+
+
+__all__ = ["supported_versions"]
+
+#: A list of specification versions supported by this
+#: package. Each version is a :code:`str`, e.g. :code:`'3.0'`.
+supported_versions = [
+    "3.0",
+    "3.1",
+]

--- a/source/openqasm/tests/test_spec.py
+++ b/source/openqasm/tests/test_spec.py
@@ -1,0 +1,17 @@
+import re
+
+
+from openqasm3.spec import supported_versions
+
+
+class TestSupportedVersions:
+    SPEC_VERSION_RE = r"^(?P<major>[0-9]+)\.(?P<minor>[0-9]+)$"
+
+    def test_supported_versions(self):
+        assert supported_versions == ["3.0", "3.1"]
+
+    def test_types(self):
+        assert all(type(x) is str for x in supported_versions)  # noqa
+
+    def test_version_formats(self):
+        assert all(re.match(self.SPEC_VERSION_RE, x) for x in supported_versions)


### PR DESCRIPTION
### Summary

List the supported specification versions in the `openqasm3` package.

### Details and comments

In #508 and the following OpenQASM TSC meeting it was discussed that the `openqasm3` Python package version would be separate from that of the specification and that the package would support multiple specification versions. Thus it would be useful to list somewhere in the `openqasm3` package which versions of the specification are supported.

I considered adding a simple `SpecVersion` class, but I wasn't sure it was worth the (small) amount of complexity. A comparable specification version might be useful, but in the AST rather than this list of versions (e.g. so that users of the AST could check whether a version was `> SpecVersion(3, 1)`).

I'm happy to add a `SpecVersion` class and also use it in the AST, but I thought I'd start with this simpler implementation.

### Checklist

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.