### PR TITLE
Release process updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,8 +77,8 @@ Please follow the next rules for the commit messages:
 ## Development Cycle
 
 The development cycle for OpenQASM is managed in the open using Github for project management.
-TODO: When preparing a new release changes for the released version should be identified
-in the release notes (See [issue #328](https://github.com/openqasm/openqasm/issues/328)).
+Release notes are collected separately for the specification and reference parser in
+the `releasenotes` directory.
 
 ### Semantic Versioning
 The OpenQASM language uses [semantic versioning (semver)](https://semver.org/).
@@ -96,9 +96,9 @@ branch, the language specification can and will change (possible breaking)
 as new language features are introduced and refined.
 All efforts should be made to ensure that the development branch is maintained in
 a self-consistent state that is passing continuous integration (CI).
-Changes should not be merged unless they are verified by CI. TODO: The latest
-development specification of the language should be automatically published by CI
-to a fixed URL for easy access to the current development HEAD.
+Changes should not be merged unless they are verified by CI. The latest
+development specification of the language (called the live spec) is automatically
+[published by CI](https://openqasm.github.io/) for easy access to the current development HEAD.
 * `stable/<major.minor>` branches:
 Branches under `stable/<major.minor>` are used to maintain released versions of the OpenQASM
 specification. They contain the version of the specification corresponding to the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,17 @@ The OpenQASM language uses [semantic versioning (semver)](https://semver.org/).
 All official releases are identified by a valid semver (See [Tags](#tags)).
 The latest development branch (See [Branches](#branches)) is always identified
 by the semver `<next_major>.<next_minor>.0-dev` where `next_<major/minor>` are
-the target major/minor versions of the next release.
+the target major/minor versions of the next release. Specification changes that
+require backwards incompatible changes to most parsers generally will warrant
+a major version increase, while less drastic changes only warrant a minor
+version increase.
+
+### Timing of Releases
+
+The OpenQASM Technical Steering Committee is the final arbiter on when a new
+semantic version of the specification and reference parser is warranted. The TSC
+expects the cadence of releases to be dicated by the contributions provided by
+the community, and not by a time-based schedule.
 
 ### Branches
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

Apologies for the delay, snow and family illness slowed things down.

### Summary
As discussed at the 02/07/2024 TSC meeting this PR makes a few minor updates to the contributing guidelines to spell out what was decided regarding the release process.

In general we agreed to:
- Release when the TSC feels that this is warranted (e.g. based on the number or nature of changes accumulated)
- Spec changes that require backwards incompatible changes at the parsing level warrants a major version bump. 
- Release v3.1 for the switch and other recent updates.

For the parser:
- The reference parser is an example implementation and not the true specification. It is used to vet proposed changes to the specification as a proof that they can be parsed and do not conflict egregiously with existing constructs.
- Regarding treatment of the OpenQASM version declaration in the parser:
  - It should generally be ignored by the reference parser for version-specific feature detection/support, but
  - Warnings for non-supported constructs in a specified version are appreciated but not required.
- The current list of versions supported by the parser will be listed within the parser itself. See https://github.com/openqasm/openqasm/pull/513
- The parser is ready for a 1.0 release - supporting v3.1 of specification

TODO in upcoming PRs:
- Release notes need to be updated to separate parser and specification release notes
- Parser release notes need to be updated and cleaned up
- Spec version 3.1 needs to be tagged

