### PR TITLE
Document content of the standard library

### DIFF
--- a/releasenotes/notes/document-stdgates.inc-ff6b02348c1c2594.yaml
+++ b/releasenotes/notes/document-stdgates.inc-ff6b02348c1c2594.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    The standard-library file ``stdgates.inc`` is now formally documented in the specification.
+    Its effects match how it was described in the initial paper, and it was always intended to
+    be part of the formal specification.

--- a/source/_extensions/oq_domain.py
+++ b/source/_extensions/oq_domain.py
@@ -1,0 +1,103 @@
+import re
+import logging
+
+import sphinx
+from sphinx import addnodes
+from sphinx.directives import ObjectDescription
+from sphinx.domains import Domain, ObjType
+from sphinx.roles import XRefRole
+from sphinx.util.nodes import make_id, make_refnode
+
+_LOG = logging.getLogger(__name__)
+
+
+class OpenQASMGate(ObjectDescription):
+    # Parsing code through superset regexes - good enough for docs, where we can assume there
+    # weren't any syntax errors.
+    SIGNATURE = re.compile(
+        r"(?P<name>\w+)\s*(\((?P<params>(\s*\w+,?)*)\))?(?P<qubits>(\s*\w+,?)*)",
+        flags=re.U,
+    )
+
+    def _object_hierarchy_parts(self, sig_node):
+        return (sig_node["name"],)
+
+    def _toc_entry_node(self, sig_node):
+        return sig_node["name"]
+
+    def add_target_and_index(self, name, sig: str, signode):
+        node_id = make_id(self.env, self.state.document, "", name)
+        signode["ids"].append(node_id)
+        domain = self.env.domains["oq"]
+        domain.index_object(name, "gate", node_id)
+        self.indexnode["entries"].append(("single", name, node_id, "", None))
+
+    def handle_signature(self, sig: str, signode):
+        if (m := self.SIGNATURE.match(sig)) is None:
+            raise ValueError(f"bad gate signature: '{sig}'")
+        name = m["name"]
+        params = (
+            [param.strip() for param in m["params"].split(",")]
+            if m["params"] is not None
+            else []
+        )
+        qubits = [qubit.strip() for qubit in m["qubits"].split(",")]
+
+        # This isn't perfect (there's semantics missing), but good enough for proof-of-concept.
+        signode["name"] = name
+        signode += addnodes.desc_sig_keyword_type(text="gate")
+        signode += addnodes.desc_sig_space()
+        signode += addnodes.desc_name(name, name)
+        if params:
+            params_node = addnodes.desc_parameterlist(m["params"])
+            for param in params:
+                param_node = addnodes.desc_parameter()
+                param_node += addnodes.desc_sig_name("", param)
+                params_node += param_node
+            signode += params_node
+        for qubit in qubits:
+            signode += addnodes.desc_sig_space()
+            qubit_node = addnodes.desc_sig_name()
+            qubit_node += addnodes.desc_sig_name("", qubit)
+            signode += qubit_node
+        return name
+
+
+class QASMDomain(Domain):
+    """OpenQASM language domain."""
+
+    name = "oq"
+    label = "OpenQASM"
+    object_types = {
+        "gate": ObjType("gate", "gate"),
+    }
+    directives = {
+        "gate": OpenQASMGate,
+    }
+    roles = {
+        "gate": XRefRole(),
+    }
+    initial_data = {
+        "objects": {},
+    }
+
+    def index_object(self, name: str, objtype: str, node_id: str):
+        if name in self.data["objects"]:
+            _LOG.warning("duplicate entry for '%s'", name)
+            return
+        self.data["objects"][name] = (self.env.docname, node_id, objtype)
+
+    def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
+        if (lookup := self.data["objects"].get(target)) is None:
+            return None
+        name, node_id, objtype = lookup
+        if objtype != typ:
+            return None
+        return make_refnode(builder, fromdocname, name, node_id, [contnode], name)
+
+
+# Setup a basic Sphinx domain for documenting OpenQASM programs.
+
+def setup(app):
+    app.add_domain(QASMDomain)
+    return {"parallel_read_safe": True, "parallel_write_safe": True}

--- a/source/conf.py
+++ b/source/conf.py
@@ -12,7 +12,7 @@
 #
 import os
 import sys
-sys.path.insert(0, os.path.abspath('_extensions'))
+sys.path.insert(0, os.path.dirname(__file__))
 
 # -- Project information -----------------------------------------------------
 from typing import List
@@ -34,8 +34,14 @@ extensions = [
   'sphinx.ext.githubpages',
   'sphinxcontrib.bibtex',
   'reno.sphinxext',
-  'multifigure'
+  # These two are our custom stuff.
+  '_extensions.multifigure',
+  '_extensions.oq_domain',
 ]
+
+# Set the default object-documentation domain to the custom 'oq' domain we defined in
+# `_extensions.oq_domain`.
+primary_domain = "oq"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/source/language/comments.rst
+++ b/source/language/comments.rst
@@ -15,6 +15,9 @@ A comment block begins with ``/*`` and ends with ``*/``:
    A comment block
    */
 
+
+.. _version-string:
+
 Version string
 ==============
 

--- a/source/language/index.rst
+++ b/source/language/index.rst
@@ -27,6 +27,7 @@ semantics.
    subroutines
    scope
    directives
+   standard_library
    delays
    pulses
    openpulse

--- a/source/language/standard_library.rst
+++ b/source/language/standard_library.rst
@@ -1,0 +1,329 @@
+Standard library
+================
+
+The standard library for OpenQASM 3 consists of a single include file, called ``stdgates.inc``.
+This file can be included in an OpenQASM 3 program with the statement
+
+.. code-block::
+
+   include "stdgates.inc";
+
+Versioning
+----------
+
+The standard library is versioned directly with the language itself.  This documentation will note
+the version that any given gate in the standard library became available, and, if applicable, the
+version it was removed in.
+
+Notes for implementations
+-------------------------
+
+An implementation is not required to make the standard library available in situations where the
+OpenQASM 3 program is being interpreted in terms of the instruction set architecture of a particular
+QPU.  The rest of this section concerns only situations where the library is considered available.
+
+Implementations should consider the ``stdgates.inc`` file to be locatable, regardless of any other
+settings that they might apply around include search paths.
+
+Upon interpreting an ``include "stdgates.inc";`` statement, implementations should make available
+exactly the set of gates defined in the standard library for the language version that matches the
+:ref:`version-string statement <version-string>`, if present.  If the version statement is not
+present, the implementation should make available the gates from the language version it is parsing
+the rest of the program under.
+
+Implementations must not define gates that are not present in chosen OpenQASM 3 version, where
+doing so could cause a user program to be ill formed (for example due to a user attempting to define
+their own gate with a clashing name).
+
+An implementation is not required to supply a literal ``stdgates.inc`` file to the user.
+
+An implementation must make all the gates available as if they were defined with ``gate``
+statements with contents that match the mathematical descriptions given here, but it is explicitly
+permissible for implementations to internally treat the ``stdgates.inc`` include as a series of
+``defcal`` statements for all qubits used in the program.
+
+
+API Documentation
+-----------------
+
+The content of the standard library is documented below, including the OpenQASM version that each
+gate was introduced in.
+
+Single-qubit gates
+..................
+
+.. gate:: p(λ) a
+
+   The phase gate.  Defined by the mapping :math:`\lvert0\rangle \to \lvert0\rangle` and
+   :math:`\lvert1\rangle \to e^{i\lambda}\lvert1\rangle`.
+
+   Equivalent to ``ctrl @ gphase(λ) a``.
+
+   .. seealso::
+
+      :gate:`rz`
+         The same operation up to a global phase.
+
+      :gate:`phase`
+         An alternative name for backwards compatibility with OpenQASM 2.
+
+   .. versionadded:: 3.0
+
+.. gate:: x a
+
+   The Pauli X gate.  Defined by the mapping :math:`\lvert0\rangle \leftrightarrow \lvert1\rangle`.
+
+   .. versionadded:: 3.0
+
+.. gate:: y a
+
+   The Pauli Y gate.  Defined by the mapping :math:`\lvert0\rangle \to i\lvert1\rangle` and
+   :math:`\lvert1\rangle \to -i\lvert0\rangle`.
+
+   .. versionadded:: 3.0
+
+.. gate:: z a
+
+   The Pauli Z gate.  Defined by the mapping :math:`\lvert0\rangle \to \lvert0\rangle` and
+   :math:`\lvert1\rangle \to \lvert1\rangle`.
+
+   Equivalent to ``p(pi) a``.
+
+   .. versionadded:: 3.0
+
+.. gate:: h a
+
+   The Hadamard gate.  Defined by the mapping
+   :math:`\lvert0\rangle \to \bigl(\lvert0\rangle + \lvert1\rangle\bigr)/\sqrt2` and
+   :math:`\lvert1\rangle \to \bigl(\lvert0\rangle - \lvert1\rangle\bigr)/\sqrt2`.
+
+   .. versionadded:: 3.0
+
+.. gate:: s a
+
+   The :math:`\sqrt Z` gate (see :gate:`z`).  The square root is chosen conventionally, that is
+   the gate is equivalent to :math:`P(\pi/2)`, in terms of :gate:`p`.
+
+   .. versionadded:: 3.0
+
+.. gate:: sdg a
+
+   Adjoint of :gate:`s`.  Equivalent to :math:`P(-\pi/2)`, in terms of :gate:`p`.
+
+   .. versionadded:: 3.0
+
+.. gate:: t
+
+   The :math:`\sqrt S` gate (see :gate:`s`).  The square root is chosen conventionally, that is
+   the gate is equivalent to :math:`P(\pi/4)`, in terms of :gate:`p`.
+
+   .. versionadded:: 3.0
+
+.. gate:: tdg a
+
+   Adjoint of :gate:`t`.  Equivalent to :math:`P(-\pi/4)`, in terms of :gate:`p`.
+
+   .. versionadded:: 3.0
+
+.. gate:: sx a
+
+   The :math:`\sqrt X` gate (see :gate:`x`).
+
+   Explicitly, this has the action
+   :math:`\lvert0\rangle \to \Bigl((1 + i)\lvert0\rangle + (1 - i)\lvert1\rangle\Bigr)/2` and
+   :math:`\lvert1\rangle \to \Bigl((1 - i)\lvert0\rangle + (1 + i)\lvert1\rangle\Bigr)/2`.
+
+   .. versionadded:: 3.0
+
+.. gate:: rx(θ) a
+
+   Rotation about the :math:`X` axis: :math:`\exp(-i\theta X)`.
+
+   .. versionadded:: 3.0
+
+.. gate:: ry(θ) a
+
+   Rotation about the :math:`Y` axis: :math:`\exp(-i\theta Y)`.
+
+   .. versionadded:: 3.0
+
+.. gate:: rz(θ) a
+
+   Rotation about the :math:`Z` axis: :math:`\exp(-i\theta Z)`.  Note that this differs from
+   :gate:`p` by a global phase of half the rotation angle.
+
+   .. seealso::
+      :gate:`p`
+         The same gate but with a different global-phase convention.
+
+   .. versionadded:: 3.0
+
+
+Two-qubit gates
+...............
+
+All of the controlled gates defined in the standard library follow the same conventions of the
+``ctrl`` modifier.
+Explicitly, the first qubit is the control and the second the target.
+The controlled gates are equivalent to applying the ``ctrl`` modifier to the relevant single-qubit
+gate.
+
+.. gate:: cx a, b
+
+   Controlled :math:`X` gate (see :gate:`x`).
+
+   .. seealso::
+      :gate:`CX`
+         An all-caps alias for backwards compatibility with OpenQASM 2.0.
+
+   .. versionadded:: 3.0
+
+.. gate:: cy a, b
+
+   Controlled :math:`Y` gate (see :gate:`y`).
+
+   .. versionadded:: 3.0
+
+.. gate:: cz a, b
+
+   Controlled :math:`Z` gate (see :gate:`z`).
+
+   .. versionadded:: 3.0
+
+.. gate:: cp(λ) a, b
+
+   Controlled :math:`P` gate with an angle :math:`\lambda` (see :gate:`p`).
+
+   The difference in global phase between :gate:`p` and :gate:`rz` makes :gate:`cp` and :gate:`crz`
+   distinct in their action.
+
+   .. versionadded:: 3.0
+
+.. gate:: crx(λ) a, b
+
+   Controlled :math:`X` rotation with an angle :math:`\theta` (see :gate:`rx`).
+
+   .. versionadded:: 3.0
+
+.. gate:: cry(λ) a, b
+
+   Controlled :math:`Y` rotation with an angle :math:`\theta` (see :gate:`ry`).
+
+   .. versionadded:: 3.0
+
+.. gate:: crz(λ) a, b
+
+   Controlled :math:`Z` rotation with an angle :math:`\theta` (see :gate:`rz`).
+
+   The difference in global phase between :gate:`p` and :gate:`rz` makes :gate:`cp` and :gate:`crz`
+   distinct in their action.
+
+   .. versionadded:: 3.0
+
+.. gate:: ch a, b
+
+   Controlled Hadamard gate (see :gate:`h`).
+
+   .. versionadded:: 3.0
+
+.. gate:: cu(θ, φ, λ, γ) a, b
+
+   A four-parameter version the controlled-:math:`U` gate.  In contrast to other standard-library
+   controll gates, this gate as an additional parameter over its base :gate:`u` gate.
+   The fourth parameter, :math:`\gamma`, controls the relative phase of the controlled operation.
+
+   Explicitly, the action in terms of :math:`U` is
+
+   .. math::
+
+      CU(\theta, \phi, \lambda, \gamma) =
+         {\lvert0\rangle\langle0\rvert}_a \otimes \mathbb{I}_b
+         + e^{i\gamma} {\lvert1\rangle\langle1\rvert}_a \otimes U(\theta, \phi, \lambda)_b
+
+   where subscripts denote the qubit being acted upon.
+
+   .. versionadded:: 3.0
+
+.. gate:: swap a, b
+
+   Swap the states of qubits ``a`` and ``b``.
+
+   .. versionadded:: 3.0
+
+
+Three-qubit gates
+.................
+
+.. gate:: ccx a, b, c
+
+   The double-controlled :math:`X` gate (see :gate:`x` and :gate:`cx`).  Also known as the Toffoli
+   gate.  The first two qubits are the controls and the last is the target.
+
+   .. versionadded:: 3.0
+
+.. gate:: cswap a, b, c
+
+   The controlled swap (see :gate:`swap`).  The first qubit is the control, and the last two are the
+   swap targets.
+
+   .. versionadded:: 3.0
+
+
+OpenQASM 2.0 compatibility
+..........................
+
+Both OpenQASM 2.0 and OpenQASM 3 define the builtin :gate:`U` gate (though note that OpenQASM 3
+differs from OpenQASM 2 by a phase; :gate:`u3` is identical to the ``U`` of OpenQASM 2).  In
+addition, OpenQASM 2.0 had a :gate:`CX` builtin, which in OpenQASM 3.0 is provided as an alias
+convenience only by ``stdgates.inc``, since the ``ctrl`` modifier made it unnecessary as a builtin.
+
+.. gate:: CX a, b
+
+   A convenience alias for :gate:`cx`.
+
+While OpenQASM 2.0 had no formal standard library, the content of the original IBM Quantum
+Experience include file ``qelib1.inc`` was described in the paper, and this became an informal, *de
+facto* standard library of the language.
+
+Most of the standard gates in it are described above.  In addition, ``qelib1.inc`` included some
+aliases for other gates, and :math:`ZYZ` Euler-rotation gates :gate:`u1`, :gate:`u2` and :gate:`u3`.
+These are reproduced in ``stdgates.inc`` to ease the transition.
+
+.. gate:: phase(λ) a
+
+   Alias for :gate:`p`.
+
+   .. versionadded:: 3.0
+
+.. gate:: cphase(λ) a, b
+
+   Alias for :gate:`cp`.
+
+   .. versionadded:: 3.0
+
+.. gate:: id a
+
+   Single-qubit identity gate.  This gate is an explicit no-op in idealized mathematical terms, but
+   an implementation is free to assign a duration to it (as with any gate), if desired.
+
+   .. versionadded:: 3.0
+
+.. gate:: u1(λ) a
+
+   Single-argument form of the OpenQASM 2.0 ``U`` gate.  Equivalent to :gate:`p`.
+
+   .. versionadded:: 3.0
+
+.. gate:: u2(φ, λ) a
+
+   Two-argument form of the OpenQASM 2.0 ``U`` gate.  Equivalent to ``u3(π/2, φ, λ)`` (see
+   :gate:`u3`).
+
+   .. versionadded:: 3.0
+
+.. gate:: u3(θ, φ, λ) a
+
+   Three-argument form of the OpenQASM 2.0 ``U`` gate.  Note that this differs from the OpenQASM 3
+   definition of ``U`` by an additional factor of :math:`e^{-i(\theta + \phi + \lambda)/2)}`.
+
+   .. versionadded:: 3.0


### PR DESCRIPTION
### Summary

This describes the effects of the `stdgates.inc` include file as part of the language specification.  I deliberately did not include the `examples/stdgates.inc` version of it in the specification to avoid implications that it *must* be implemented with that manner, but attempted to explain how implementations must behave *as if* if were defined like this, so that implementations are free to interpret the file in terms of `defcal` statements or the like (if they were to so choose).

This commit also includes a brief Sphinx extension, to make it possible to document OpenQASM gates in the full Sphinx structure.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->


### Details and comments

Close #516.

The text here is largely just a first draft - happy for any suggestions to the requirements, or different ways of presenting things.

It probably makes sense for me to split of the Sphinx extension into a separately installable Python package, but just for the purposes of demoing this PR, I've included it inline here.  If we want it, I'll sort out the legal stuff for my work on it on the IBM side (since here, it's just folded into the licensing for this repo) and move it into a separate repo.  The current implementation is bare bones and just enough to document what I needed to.