### PR TITLE
Add separate reno sections for specification and ast/grammar

### DIFF
--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -4,3 +4,115 @@ default_branch: main
 collapse_pre_releases: true
 branch_name_prefix: release/
 branch_name_re: release/.+
+sections:
+  # The prelude section is implicitly included.
+  # top-level section for spec release notes
+  - [specification_changes, Specification, 1]
+  - [spec_features, New Features, 2]
+  - [spec_issues, Known Issues, 2]
+  - [spec_upgrade, Upgrade Notes, 2]
+  - [spec_deprecations, Deprecations, 2]
+  - [spec_fixes, Bug Fixes, 2]
+  - [spec_other, Other, 2]
+  # top-level section for grammar and ast release notes
+  - [ast_changes, Grammar and AST, 1]
+  - [ast_features, New Features, 2]
+  - [ast_issues, Known Issues, 2]
+  - [ast_upgrade, Upgrade Notes, 2]
+  - [ast_deprecations, Deprecations, 2]
+  - [ast_fixes, Bug Fixes, 2]
+  - [ast_other, Other, 2]
+template: |+
+  ---
+  prelude: >
+      Replace this text with content to appear at the top of the section for this
+      release. All of the prelude content is merged together and then rendered
+      separately from the items listed in other parts of the file, so the text
+      needs to be worded so that both the prelude and the other items make sense
+      when read independently. This may mean repeating some details. Not every
+      release note requires a prelude. Usually only notes describing major
+      features or adding release theme details should have a prelude.
+  spec_features:
+    - |
+      List new features here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  spec_issues:
+    - |
+      List known issues here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  spec_upgrade:
+    - |
+      List upgrade notes here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  spec_deprecations:
+    - |
+      List deprecations notes here, or remove this section.  All of the list
+      items in this section are combined when the release notes are rendered, so
+      the text needs to be worded so that it does not depend on any information
+      only available in another section, such as the prelude. This may mean
+      repeating some details.
+  spec_fixes:
+    - |
+      Add normal bug fixes here, or remove this section.  All of the list items
+      in this section are combined when the release notes are rendered, so the
+      text needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  spec_other:
+    - |
+      Add other notes here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  ast_features:
+    - |
+      List new features here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  ast_issues:
+    - |
+      List known issues here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  ast_upgrade:
+    - |
+      List upgrade notes here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  ast_deprecations:
+    - |
+      List deprecations notes here, or remove this section.  All of the list
+      items in this section are combined when the release notes are rendered, so
+      the text needs to be worded so that it does not depend on any information
+      only available in another section, such as the prelude. This may mean
+      repeating some details.
+  ast_fixes:
+    - |
+      Add normal bug fixes here, or remove this section.  All of the list items
+      in this section are combined when the release notes are rendered, so the
+      text needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.
+  ast_other:
+    - |
+      Add other notes here, or remove this section.  All of the list items in
+      this section are combined when the release notes are rendered, so the text
+      needs to be worded so that it does not depend on any information only
+      available in another section, such as the prelude. This may mean repeating
+      some details.

--- a/releasenotes/config.yaml
+++ b/releasenotes/config.yaml
@@ -22,6 +22,9 @@ sections:
   - [ast_deprecations, Deprecations, 2]
   - [ast_fixes, Bug Fixes, 2]
   - [ast_other, Other, 2]
+semver_major: spec_upgrade
+semver_minor: spec_features
+semver_patch: spec_fixes
 template: |+
   ---
   prelude: >

--- a/releasenotes/notes/add-releasenote-checks-78194cf9de8ded3e.yaml
+++ b/releasenotes/notes/add-releasenote-checks-78194cf9de8ded3e.yaml
@@ -1,7 +1,11 @@
 ---
-features:
+spec_features:
   - |
     Added CI support for ensuring contributions include a release note.
     If this is not desired for a PR the tag "no-reno" may be added to the
     PR.
-
+ast_features:
+  - |
+    Added CI support for ensuring contributions include a release note.
+    If this is not desired for a PR the tag "no-reno" may be added to the
+    PR.

--- a/releasenotes/notes/add-supported-spec-versions-to-openqasm3-pkg-7ea92eb1181bf0fd.yaml
+++ b/releasenotes/notes/add-supported-spec-versions-to-openqasm3-pkg-7ea92eb1181bf0fd.yaml
@@ -1,5 +1,5 @@
 ---
-features:
+ast_features:
   - |
     Added `openqasm3.spec.supported_versions` which lists the OpenQASM specification
     versions supported by the `openqasm3` package. Currently the supported versions

--- a/releasenotes/notes/clarify-physical-qubits-f720f21a3d792c70.yaml
+++ b/releasenotes/notes/clarify-physical-qubits-f720f21a3d792c70.yaml
@@ -1,5 +1,5 @@
 ---
-upgrade:
+spec_upgrade:
   - |
     Improve physical qubit documentation. Define what constitutes a valid
     physical identifier, define physical circuits, and answer several questions

--- a/releasenotes/notes/drop-dollar-from-pulse-wildcard-2efa545932ed7736.yaml
+++ b/releasenotes/notes/drop-dollar-from-pulse-wildcard-2efa545932ed7736.yaml
@@ -1,5 +1,5 @@
 ---
-upgrade:
+spec_upgrade:
   - |
     The "wildcard" identifiers in pulse grammars are now regular OpenQASM 3
     identifiers, without the leading dollar sign (``$``), *e.g.* what was ``$q``

--- a/releasenotes/notes/remove-reserved-switch-keywords-df5ea30f6e775f22.yaml
+++ b/releasenotes/notes/remove-reserved-switch-keywords-df5ea30f6e775f22.yaml
@@ -1,5 +1,5 @@
 ---
-other:
+spec_other:
   - |
     The keywords ``switch``, ``case``, and ``default`` are no longer reserved
     by the spec for future expansion of the language.

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Sphinx>=4.0
 sphinxcontrib-bibtex
 openqasm_pygments~=0.1.0
 pylint
-reno
+reno>=4.1.0
 
 # `sphinxcontrib-bibtex` uses `pkg_resources` from `setuptools` but fails
 # to specify it as an actual runtime dependency, so we do it for them.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

This is the first alternative for releasing versions of the specification and ast/grammar separately, the other option is #519. 
Create separate reno sections for specification and ast/grammar updates. 

### Details and comments

I've added `spec_*` and `ast_*` sections to the reno notes, along with a template including those sections/subsections. I've also updated the existing notes with the correct sections.

