### PR TITLE
Add GitHub link to the live doc

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -73,6 +73,8 @@ if version_list_var is not None:
     for ver in version_list:
         extra_nav_links[f'Version {ver}'] = f'/versions/{ver}/index.html'
 
+extra_nav_links["GitHub"] = "https://github.com/openqasm/openqasm/"
+
 print(extra_nav_links)
 
 # Theme specific options

--- a/source/index.rst
+++ b/source/index.rst
@@ -8,6 +8,7 @@ OpenQASM |version| Specification
   language/index
   grammar/index
   release_notes
+  GitHub <https://github.com/openqasm/openqasm/>
 
 Bibliography
 ============


### PR DESCRIPTION
### Summary
Added the GitHub link to the navigation panel in the live doc as a static external link, referencing issue #69 

### Details and comments
The original issue post mentions adding links to making issues and pull requests, but a single GitHub link likely suffices to direct the user and appears cleaner, so only the main link has been added.