### PR TITLE
Add missing type annotation to loop variable in for loop examples

### DIFF
--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -344,9 +344,9 @@ accessible after the loop.
 
    // Loop over a register of bits.
    bit[5] register;
-   for b in register {}
+   for bit b in register {}
    let alias = register[1:3];
-   for b in alias {}
+   for bit b in alias {}
 
 
 While loops

--- a/source/language/openpulse.rst
+++ b/source/language/openpulse.rst
@@ -691,7 +691,7 @@ Here we want to sweep the frequency of a long pulse that saturates the qubit tra
       set_frequency(driveframe, frequency_start);
   }
 
-  for i in [1:frequency_num_steps] {
+  for int i in [1:frequency_num_steps] {
       // step into a `cal` block to adjust the pulse frequency via the frame frequency
       cal {
           shift_frequency(driveframe, frequency_step);
@@ -875,7 +875,7 @@ The program aims to perform a Hahn echo sequence on q1, and a Ramsey sequence on
   }
 
   // Ramsey sequence on qubit 1 and 3, Hahn echo on qubit 2
-  for τ in [0:10us:1ms] {
+  for duration τ in [0:10us:1ms] {
 
     // First π/2 pulse
     rx(π/2) $0, $1, $2;
@@ -886,7 +886,7 @@ The program aims to perform a Hahn echo sequence on q1, and a Ramsey sequence on
     }
 
     // Hahn echo π pulse composed of two π/2 pulses
-    for ct in [0:1]:
+    for int ct in [0:1]:
       rx(π/2) $2;
 
     cal {

--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -50,7 +50,7 @@ subroutine that takes qubits and registers::
 
    def xcheck(qubit[4] d, qubit a) -> bit {
      reset a;
-     for i in [0: 3] cx d[i], a;
+     for int i in [0: 3] cx d[i], a;
      return measure a;
    }
 
@@ -61,7 +61,7 @@ instructions, like::
    const n = /* some size, known at compile time */;
    def parity(bit[n] cin) -> bit {
      bit c;
-     for i in [0: n - 1] {
+     for int i in [0: n - 1] {
        c ^= cin[i];
      }
      return c;
@@ -143,8 +143,8 @@ subscripted, meaning that ``sizeof(arr[0], 0) == sizeof(arr, 1)``.
      uint[32] firstDim  = sizeof(twoD_arg, 0);
      uint[32] secondDim = sizeof(twoD_arg, 1);
      int[32] sum = 0;
-     for ii in [0:firstDim-1] {
-       for jj in [0:secondDim-1] {
+     for int ii in [0:firstDim-1] {
+       for int jj in [0:secondDim-1] {
          sum += int[32](twoD_arg[ii][jj]);
        }
      }


### PR DESCRIPTION
In several examples of `for` loops in the language specification there is no annotation, or type specification, on the loop variable. According to the spec omitting the annotation is not allowed.

This commit corrects each such instance by adding an annotation.