### PR TITLE
Replace an occurrence of stdgates.qasm with stdgates.inc

### DIFF
--- a/releasenotes/notes/remove-incorrect-stdgates-file-d6a93fe18dbe669e.yaml
+++ b/releasenotes/notes/remove-incorrect-stdgates-file-d6a93fe18dbe669e.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Remove `include "stdgates.qasm";` from an example in the specification. This
+    file name has no special significance. This line could easily be confused
+    with `include "stdgates.inc";`, which is the only specified method of
+    including gate definitions from the standard library.

--- a/source/language/comments.rst
+++ b/source/language/comments.rst
@@ -42,6 +42,6 @@ This statement can only be used at the global scope.
    // First non-comment is a version string
    OPENQASM 3.0;
 
-   include "stdgates.qasm";
+   include "stdgates.inc";
 
    // Rest of QASM program


### PR DESCRIPTION
In another PR We are adding behavior around stdgates.inc to the spec, and the name of the file is fixed. The appearance of `include "stdgates.qasm"` here is confusing because it looks like it is including the standard library declarations, but in fact is not.

* See #517