### PR TITLE
Correct integer division in `pow` modifiers

### DIFF
--- a/examples/stdgates.inc
+++ b/examples/stdgates.inc
@@ -1,4 +1,10 @@
-// OpenQASM 3 standard gate library
+// OpenQASM 3.0 standard gate library
+//
+// Note: the gates defined by this file are exactly the set that the OpenQASM
+// 3.0 specification defined, as are the unitary actions, but implementations
+// have some scope for how they handle the file internally.  See the
+// `source/language/standard_library.rst` documentation for full detail.
+
 
 // phase gate
 gate p(λ) a { ctrl @ gphase(λ) a; }
@@ -13,17 +19,17 @@ gate z a { p(π) a; }
 // Clifford gate: Hadamard
 gate h a { U(π/2, 0, π) a; gphase(-π/4);}
 // Clifford gate: sqrt(Z) or S gate
-gate s a { pow(1/2) @ z a; }
+gate s a { pow(1./2.) @ z a; }
 // Clifford gate: inverse of sqrt(Z)
-gate sdg a { inv @ pow(1/2) @ z a; }
+gate sdg a { inv @ pow(1./2.) @ z a; }
 
 // sqrt(S) or T gate
-gate t a { pow(1/2) @ s a; }
+gate t a { pow(1./2.) @ s a; }
 // inverse of sqrt(S)
-gate tdg a { inv @ pow(1/2) @ s a; }
+gate tdg a { inv @ pow(1./2.) @ s a; }
 
 // sqrt(NOT) gate
-gate sx a { pow(1/2) @ x a; }
+gate sx a { pow(1./2.) @ x a; }
 
 // Rotation around X-axis
 gate rx(θ) a { U(θ, -π/2, π/2) a; gphase(-θ/2);}

--- a/releasenotes/notes/pow-stdgates-3adfb62d8f08b1f8.yaml
+++ b/releasenotes/notes/pow-stdgates-3adfb62d8f08b1f8.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Corrected the sample definitions of square-root gates involving ``pow`` in the ``stdgates.inc``
+    example file to use floating-point division ``1./2.`` instead of integer division ``1/2``.

--- a/source/grammar/tests/reference/gate/gate_modifiers.yaml
+++ b/source/grammar/tests/reference/gate/gate_modifiers.yaml
@@ -4,7 +4,7 @@ source: |
   gate g q {}
   ctrl(2) @ g q;
   negctrl(3) @ g q;
-  pow(-1/2) @ g q;
+  pow(-1./2.) @ g q;
   inv @ g q;
 reference: |
   program
@@ -67,10 +67,10 @@ reference: |
               expression
                 -
                 expression
-                  1
+                  1.
               /
               expression
-                2
+                2.
             )
             @
           g

--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -535,7 +535,7 @@ class QuantumGateModifier(QASMNode):
     Example::
 
         inv @
-        pow(1/2)
+        pow(1./2.)
         ctrl
     """
 


### PR DESCRIPTION
### Summary

These would have been evaluted to the integer `0` instead of the intended floating-point value `0.5`.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->


### Details and comments

Fix #528

