### PR TITLE
Add associativity to operator-precedence table

### DIFF
--- a/releasenotes/notes/associativity-table-19470d1891f44247.yaml
+++ b/releasenotes/notes/associativity-table-19470d1891f44247.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    The section on classical instructions now lists the associativity of all operators in the
+    precedence table, and correctly identifies the power operator as being right-associative.  The
+    previous description of the precedence and associativity was at best imprecise.

--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -213,39 +213,32 @@ hardware-dependent rounding mode and subnormal handling.
 Evaluation order
 ~~~~~~~~~~~~~~~~
 
-OpenQASM evaluates expressions from left to right.
+OpenQASM evaluates expressions in natural mathematical order, following the defined
+operator-precedence and -associativity table below.  Operators of greater precedence are evaluated
+before operators of less precedence.  The order of evaluation for operators of the same precedence
+is set by the associativity: left-associative operators evaluate from left to right (*i.e.* ``a + b
++ c`` evaluates as ``(a + b) + c``) while right-associative operators evaluate from right to left
+(*i.e.* ``a ** b ** c`` evaluates as ``a ** (b ** c)``).
 
-   .. table:: [operator-precedence] operator precedence in OpenQASM ordered from highest precedence to lowest precedence. Higher precedence operators will be evaluated first.
+.. table:: [operator-precedence] operator precedence in OpenQASM ordered from highest precedence to lowest precedence. Higher precedence operators will be evaluated first.
 
-      +----------------------------------------+------------------------------------+
-      | Operator                               | Operator Types                     |
-      +----------------------------------------+------------------------------------+
-      | ``()``, ``[]``, ``(type)(x)``          | Call, index, cast                  |
-      +----------------------------------------+------------------------------------+
-      | ``**``                                 | Power                              |
-      +----------------------------------------+------------------------------------+
-      | ``!``, ``-``, ``~``                    | Unary                              |
-      +----------------------------------------+------------------------------------+
-      | ``*``, ``/``, ``%``                    | Multiplicative                     |
-      +----------------------------------------+------------------------------------+
-      | ``+``, ``-``                           | Additive                           |
-      +----------------------------------------+------------------------------------+
-      | ``<<``, ``>>``                         | Bit Shift                          |
-      +----------------------------------------+------------------------------------+
-      | ``<``, ``<=``, ``>``, ``>=``           | Comparison                         |
-      +----------------------------------------+------------------------------------+
-      | ``!=``, ``==``                         | Equality                           |
-      +----------------------------------------+------------------------------------+
-      | ``&``                                  | Bitwise AND                        |
-      +----------------------------------------+------------------------------------+
-      | ``^``                                  | Bitwise XOR                        |
-      +----------------------------------------+------------------------------------+
-      | ``|``                                  | Bitwise OR                         |
-      +----------------------------------------+------------------------------------+
-      | ``&&``                                 | Logical AND                        |
-      +----------------------------------------+------------------------------------+
-      | ``||``                                 | Logical OR                         |
-      +----------------------------------------+------------------------------------+
+   ===============================  ===================  =============
+   Operator                         Operator names       Associativity
+   ===============================  ===================  =============
+   ``()``, ``[]``, ``(type)(x)``    Call, index, cast    left
+   ``**``                           Power                right
+   ``!``, ``-``, ``~``              Unary                right
+   ``*``, ``/``, ``%``              Multiplicative       left
+   ``+``, ``-``                     Additive             left
+   ``<<``, ``>>``                   Bit Shift            left
+   ``<``, ``<=``, ``>``, ``>=``     Comparison           left
+   ``!=``, ``==``                   Equality             left
+   ``&``                            Bitwise AND          left
+   ``^``                            Bitwise XOR          left
+   ``|``                            Bitwise OR           left
+   ``&&``                           Logical AND          left
+   ``||``                           Logical OR           left
+   ===============================  ===================  =============
 
 
 Looping and branching


### PR DESCRIPTION
### Summary

This adds associativity to the operator-precedence table, matching what is found in the ANTLR grammar (i.e. all binary ops associate to the left except for power, which associates to the right).

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Details and comments

Close #530
