### PR TITLE
Fix incorrect syntax in broadcasting example.

### DIFF
--- a/releasenotes/notes/fix-broadcast-example-ffb53ef1af8d8435.yaml
+++ b/releasenotes/notes/fix-broadcast-example-ffb53ef1af8d8435.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed mistaken ``qubit`` declarations in broadcasting code example.

--- a/source/language/gates.rst
+++ b/source/language/gates.rst
@@ -28,10 +28,10 @@ this syntax is a convenient shorthand for broadcasting over the qubits of the re
 
 .. code-block::
 
-   qubit qr0[1];
-   qubit qr1[3];
-   qubit qr2[2];
-   qubit qr3[3];
+   qubit[1] qr0;
+   qubit[3] qr1;
+   qubit[2] qr2;
+   qubit[3] qr3;
 
    g4 qr0[0], qr1, qr2[0], qr3; // ok
    g4 qr0[0], qr2, qr1[0], qr3; // error! qr2 and qr3 differ in size


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

The example given for broadcasting uses the incorrect syntax for declaring quantum registers. This is a minor edit to fix the typo.

### Details and comments

The correct syntax (see, e.g., [here](https://openqasm.com/language/types.html), or even just down below in this very same doc) is:

```python
qubit[SIZE] q;
```

The current documentation incorrectly puts the size after the register name:

```python
qubit q[SIZE];
```
