### PR TITLE
Fix concatenation operator in subroutines.rst

### DIFF
--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -88,7 +88,7 @@ this::
    c = measure q;
    c2 = measure r;
    bit result;
-   result = parity(c || c2);
+   result = parity(c ++ c2);
 
 .. _arrays-in-subroutines:
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

I believe this was somehow messed up by the automated merge in 8770462875b065c09806c61a7eecdfae890a5684 (see the file [here](https://github.com/openqasm/openqasm/blob/8770462875b065c09806c61a7eecdfae890a5684/source/language/subroutines.rst)), as it was correct in 045d3a63f8e74331858445144959e3d9ff747f8c.

This now matches the other call to `parity(c ++ c2)` on line 78 in the same file.

### Details and comments


