### PR TITLE
Clarify that arrays and registers of size 0 are allowed

### DIFF
--- a/source/grammar/qasm3Parser.g4
+++ b/source/grammar/qasm3Parser.g4
@@ -164,7 +164,7 @@ declarationExpression: arrayLiteral | expression | measureExpression;
 measureExpression: MEASURE gateOperand;
 rangeExpression: expression? COLON expression? (COLON expression)?;
 setExpression: LBRACE expression (COMMA expression)* COMMA? RBRACE;
-arrayLiteral: LBRACE (expression | arrayLiteral) (COMMA (expression | arrayLiteral))* COMMA? RBRACE;
+arrayLiteral: LBRACE ((expression | arrayLiteral) (COMMA (expression | arrayLiteral))* COMMA?)? RBRACE;
 
 // The general form is a comma-separated list of indexing entities.
 // `setExpression` is only valid when being used as a single index: registers

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -218,7 +218,7 @@ There are n-bit signed and unsigned integers. The statements ``int[size] name;``
 signed 1:n-1:0 and unsigned 0:n:0 integers of the given size. The sizes
 and the surrounding brackets can be omitted (*e.g.* ``int name;``) to use
 a precision that is specified by the particular target architecture.
-If provided, the ``size`` of an unsigned integer must be at least 1, and the ``size`` of a signed integer must be at least 2.
+If provided, the ``size`` of an integer must be at least 1.
 Bit-level operations cannot be used on types without a specified width, and
 unspecified-width types are different to *all* specified-width types for
 the purposes of casting.

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -785,7 +785,7 @@ and for multi-dimensional arrays subarray accesses can be specified using a
 comma-delimited list of indices (*e.g.* ``myArr[1, 2, 3]``), with the outer
 dimension specified first.
 
-One or more dimension(s) of an array can be zero, in which case the array has size zero.  An array of size zero cannot be indexed, e.g. given ``array[float[32], 0] myArray;``, it is an error to use either ``myArray[0]`` or ``myArray[-1]``.
+One or more dimension(s) of an array can be zero, in which case the array has size zero.  An array of size zero cannot be indexed, e.g. given ``array[float[32], 0] myArray;``, it is an error to access either ``myArray[0]`` or ``myArray[-1]``.
 
 For interoperability, the standard
 ways of declaring quantum registers and bit registers are equivalent to the

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -65,7 +65,7 @@ declares a reference to a quantum bit. These qubits are referred
 to as "virtual qubits" (in distinction to "physical qubits" on
 actual hardware; see below). The statement ``qubit[size] name;``
 declares a quantum register with ``size`` qubits.
-Sizes must always be :ref:`compile-time constant <const-expression>` positive
+Sizes must always be :ref:`compile-time constant <const-expression>` non-negative
 integers.
 Quantum registers are static arrays of qubits
 that cannot be dynamically resized.
@@ -218,6 +218,7 @@ There are n-bit signed and unsigned integers. The statements ``int[size] name;``
 signed 1:n-1:0 and unsigned 0:n:0 integers of the given size. The sizes
 and the surrounding brackets can be omitted (*e.g.* ``int name;``) to use
 a precision that is specified by the particular target architecture.
+If provided, the ``size`` of an unsigned integer must be at least 1, and the ``size`` of an unsigned integer must be at least 2.
 Bit-level operations cannot be used on types without a specified width, and
 unspecified-width types are different to *all* specified-width types for
 the purposes of casting.
@@ -291,8 +292,8 @@ multiplication and division by unsigned integers is defined by standard
 unsigned-integer arithmetic, with more details found in :ref:`the section on
 classical instructions <classical-instructions>`.
 
-The statement ``angle[size] name;`` statement declares a new angle called
-``name`` with ``size`` bits in its representation.  Angles can be assigned
+The statement ``angle[size] name;`` declares a new angle called
+``name`` with ``size`` bits in its representation, where ``size`` must be a positive integer.  Angles can be assigned
 values using the constant ``π`` or ``pi``, such as::
 
    // Declare a 20-bit angle with the value of "π/2"
@@ -783,6 +784,8 @@ of 7 total dimensions. The subscript operator ``[]`` is used for element access,
 and for multi-dimensional arrays subarray accesses can be specified using a
 comma-delimited list of indices (*e.g.* ``myArr[1, 2, 3]``), with the outer
 dimension specified first.
+
+One or more dimension(s) of an array can be zero, in which case the array has size zero.  An array of size zero cannot be indexed, e.g. given ``array[float[32], 0] myArray;``, it is an error to use either ``myArray[0]`` or ``myArray[-1]``.
 
 For interoperability, the standard
 ways of declaring quantum registers and bit registers are equivalent to the

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -218,7 +218,7 @@ There are n-bit signed and unsigned integers. The statements ``int[size] name;``
 signed 1:n-1:0 and unsigned 0:n:0 integers of the given size. The sizes
 and the surrounding brackets can be omitted (*e.g.* ``int name;``) to use
 a precision that is specified by the particular target architecture.
-If provided, the ``size`` of an unsigned integer must be at least 1, and the ``size`` of an unsigned integer must be at least 2.
+If provided, the ``size`` of an unsigned integer must be at least 1, and the ``size`` of a signed integer must be at least 2.
 Bit-level operations cannot be used on types without a specified width, and
 unspecified-width types are different to *all* specified-width types for
 the purposes of casting.

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -368,6 +368,9 @@ def test_array_declaration():
     array[int, 0] a;
     array[int, 2, 0] a;
     array[int, 0, 2] a;
+    array[int, 0] a = {};
+    array[int, 2, 0] a = {{}, {}};
+    array[int, 0, 2] a = {};
     """.strip()
     program = parse(p)
     a, b = Identifier("a"), Identifier("b")
@@ -433,6 +436,23 @@ def test_array_declaration():
                 type=ArrayType(base_type=IntType(size=None), dimensions=[zero, two]),
                 identifier=a,
                 init_expression=None,
+            ),
+            ClassicalDeclaration(
+                type=ArrayType(base_type=IntType(size=None), dimensions=[zero]),
+                identifier=a,
+                init_expression=ArrayLiteral([]),
+            ),
+            ClassicalDeclaration(
+                type=ArrayType(base_type=IntType(size=None), dimensions=[two, zero]),
+                identifier=a,
+                init_expression=ArrayLiteral(
+                    [ArrayLiteral([]), ArrayLiteral([])],
+                ),
+            ),
+            ClassicalDeclaration(
+                type=ArrayType(base_type=IntType(size=None), dimensions=[zero, two]),
+                identifier=a,
+                init_expression=ArrayLiteral([]),
             ),
         ],
     )

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -2076,7 +2076,6 @@ class TestFailurePaths:
 
     @pytest.mark.parametrize("scalar", ("uint", "int", "angle"))
     def test_nonpositive_width_integer(self, scalar):
-        assert False  # FIXME: not sure why this test is not being invoked
         message = f"{scalar} size must be positive"
         with pytest.raises(QASM3ParsingError, match=message):
             parse(f"{scalar}[0] a;")
@@ -2084,7 +2083,7 @@ class TestFailurePaths:
             parse(f"{scalar}[-1] a;")
 
     @pytest.mark.parametrize("oldstylereg", ("qreg", "creg"))
-    def test_nonpositive_width_integer(self, oldstylereg):
+    def test_nonpositive_width_register(self, oldstylereg):
         message = f"{oldstylereg} size must be positive"
         with pytest.raises(QASM3ParsingError, match=message):
             parse(f"{oldstylereg} a[0];")

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -120,15 +120,14 @@ def test_qubit_declaration():
     p = """
     qubit q;
     qubit[4] a;
+    qubit[0] b;
     """.strip()
     program = parse(p)
     assert _remove_spans(program) == Program(
         statements=[
             QubitDeclaration(qubit=Identifier(name="q"), size=None),
-            QubitDeclaration(
-                qubit=Identifier(name="a"),
-                size=IntegerLiteral(4),
-            ),
+            QubitDeclaration(qubit=Identifier(name="a"), size=IntegerLiteral(4)),
+            QubitDeclaration(qubit=Identifier(name="b"), size=IntegerLiteral(0)),
         ]
     )
     SpanGuard().visit(program)
@@ -140,10 +139,16 @@ def test_qubit_declaration():
 def test_bit_declaration():
     p = """
     bit c;
+    bit[4] c;
+    bit[0] c;
     """.strip()
     program = parse(p)
     assert _remove_spans(program) == Program(
-        statements=[ClassicalDeclaration(BitType(None), Identifier("c"), None)]
+        statements=[
+            ClassicalDeclaration(BitType(None), Identifier("c"), None),
+            ClassicalDeclaration(BitType(IntegerLiteral(4)), Identifier("c"), None),
+            ClassicalDeclaration(BitType(IntegerLiteral(0)), Identifier("c"), None),
+        ]
     )
     SpanGuard().visit(program)
     classical_declaration = program.statements[0]
@@ -173,10 +178,12 @@ def test_integer_declaration():
     uint[16] a = 0o144;
     uint[16] a = 0xff_64;
     int[16] a = 0X19_a_b;
+    uint[4] a = 2;
     """.strip()
     program = parse(p)
     uint16 = UintType(IntegerLiteral(16))
     int16 = IntType(IntegerLiteral(16))
+    uint4 = UintType(IntegerLiteral(4))
     a = Identifier("a")
     assert _remove_spans(program) == Program(
         statements=[
@@ -186,6 +193,7 @@ def test_integer_declaration():
             ClassicalDeclaration(uint16, a, IntegerLiteral(0o144)),
             ClassicalDeclaration(uint16, a, IntegerLiteral(0xFF64)),
             ClassicalDeclaration(int16, a, IntegerLiteral(0x19AB)),
+            ClassicalDeclaration(uint4, a, IntegerLiteral(2)),
         ]
     )
     SpanGuard().visit(program)
@@ -357,9 +365,13 @@ def test_array_declaration():
     array[float[32], 2, 2] a;
     array[complex[float[64]], 2, 2] a = {{1, 1}, {2, 2}};
     array[uint[8], 2, 2] a = {b, b};
+    array[int, 0] a;
+    array[int, 2, 0] a;
+    array[int, 0, 2] a;
     """.strip()
     program = parse(p)
     a, b = Identifier("a"), Identifier("b")
+    zero = IntegerLiteral(0)
     one, two, eight = IntegerLiteral(1), IntegerLiteral(2), IntegerLiteral(8)
     SpanGuard().visit(program)
     assert _remove_spans(program) == Program(
@@ -406,6 +418,21 @@ def test_array_declaration():
                 type=ArrayType(base_type=UintType(eight), dimensions=[two, two]),
                 identifier=a,
                 init_expression=ArrayLiteral([b, b]),
+            ),
+            ClassicalDeclaration(
+                type=ArrayType(base_type=IntType(size=None), dimensions=[zero]),
+                identifier=a,
+                init_expression=None,
+            ),
+            ClassicalDeclaration(
+                type=ArrayType(base_type=IntType(size=None), dimensions=[two, zero]),
+                identifier=a,
+                init_expression=None,
+            ),
+            ClassicalDeclaration(
+                type=ArrayType(base_type=IntType(size=None), dimensions=[zero, two]),
+                identifier=a,
+                init_expression=None,
             ),
         ],
     )
@@ -2014,3 +2041,32 @@ class TestFailurePaths:
         message = "invalid scalar type for array"
         with pytest.raises(QASM3ParsingError, match=message):
             parse(f"array[stretch, 4] arr;")
+
+    @pytest.mark.parametrize(
+        "array",
+        (
+            "array[uint, -1]",
+            "array[int, -2, -2]",
+        ),
+    )
+    def test_array_with_negative_dimension(self, array):
+        message = "all array dimensions must be non-negative"
+        with pytest.raises(QASM3ParsingError, match=message):
+            parse(f"{array} arr;")
+
+    @pytest.mark.parametrize("scalar", ("uint", "int", "angle"))
+    def test_nonpositive_width_integer(self, scalar):
+        assert False  # FIXME: not sure why this test is not being invoked
+        message = f"{scalar} size must be positive"
+        with pytest.raises(QASM3ParsingError, match=message):
+            parse(f"{scalar}[0] a;")
+        with pytest.raises(QASM3ParsingError, match=message):
+            parse(f"{scalar}[-1] a;")
+
+    @pytest.mark.parametrize("oldstylereg", ("qreg", "creg"))
+    def test_nonpositive_width_integer(self, oldstylereg):
+        message = f"{oldstylereg} size must be positive"
+        with pytest.raises(QASM3ParsingError, match=message):
+            parse(f"{oldstylereg} a[0];")
+        with pytest.raises(QASM3ParsingError, match=message):
+            parse(f"{oldstylereg} a[-1];")

--- a/spec_releasenotes/releasenotes/notes/empty-arrays-and-registers-55cbdf24c8a66322.yaml
+++ b/spec_releasenotes/releasenotes/notes/empty-arrays-and-registers-55cbdf24c8a66322.yaml
@@ -1,4 +1,6 @@
 ---
 upgrade:
   - |
-    Clarify that arrays and registers of size zero are allowed.
+    It has been clarified that arrays and registers of size zero are
+    allowed; however, integers and angles must have size greater than
+    zero.

--- a/spec_releasenotes/releasenotes/notes/empty-arrays-and-registers-55cbdf24c8a66322.yaml
+++ b/spec_releasenotes/releasenotes/notes/empty-arrays-and-registers-55cbdf24c8a66322.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Clarify that arrays and registers of size zero are allowed.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Fixes #532.

### Details and comments

The primary change is to make it so a "size" can be a non-negative integer instead of a positive integer.  This works for qubits as well as classical bits/registers, but it leads to some clarifications being necessary for some other types:

- Integers of zero bits are explicitly forbidden by this PR.  An ~~unsigned~~ integer must have at least one bit.  ~~A signed integer must have at least two bits (the sign bit plus one integer bit).  The latter was probably implicitly assumed before, but now it is explicit.~~  NOTE: I saw nothing specifying that an integer must have a "normal" number of bits, i.e., 8, 16, 32, or 64, even though the examples tend to use these values.
- Floating point numbers must have a number of bits that corresponds to a valid IEEE 754 floating point type, so I believe it is unnecessary to explicitly say that zero bits are forbidden.
- Like unsigned integers, angles must have at least one bit.
- I added a statement permitting arrays to have dimension(s) which are of length zero.  I avoided the word "length" because it is currently not used to describe the individual dimensions given by the shape.  I am open to rephrasing this with guidance.
 
#### Remaining action items

- [x] add a release note
- [x] add tests for the parser
- [x] get tests to pass
- [x] revise release note: make it more specific