### PR TITLE
Update Program.statements to allow `Pragma` entries

### DIFF
--- a/ast_releasenotes/releasenotes/notes/program-statements-pragma-79317e8c52e8fb95.yaml
+++ b/ast_releasenotes/releasenotes/notes/program-statements-pragma-79317e8c52e8fb95.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Update the `Program.statements` type annotation to allow `Pragma`.

--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -138,7 +138,7 @@ class Program(QASMNode):
     An entire OpenQASM 3 program represented by a list of top level statements
     """
 
-    statements: List[Statement]
+    statements: List[Union[Statement, Pragma]]
     version: Optional[str] = None
 
 


### PR DESCRIPTION
The OpenQASM spec allows `pragma` statements in the body of a program, and the parser does too. For example,

```
In [3]: prog = parse("pragma foo\n  int x;")

In [4]: prog.statements[0]
Out[4]: Pragma(span=Span(start_line=1, start_column=0, end_line=1, end_column=7), command='foo')
```

However, the actual type annotation of `Program.statements` is `List[Statement]`, whereas `Pragma` is not a subtype of `Statement`. There seem to be a few options in remedying this:
1. Add a `Program.pragmas` field, and have the parser populate this. This would be a breaking change.
2. Make `Pragma` a statement. Because pragmas are messages to language processors, they do not carry any intrinsic semantic content. We could just define them to be "no-op" statements.
3. Just formally allow for `Program.statements` to carry statements or pragmas. This is more or less what we do today -- I'm just asking to fix the type annotation.

This PR proposes (3).
