### PR TITLE
Declare `bit`/`bool` equivalence and differences between `bit[n]` and `array[T, n]`

### DIFF
--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -211,7 +211,7 @@ bit is on the right.
    bit[8] name = "00001111";
 
 
-The scalar type ``bit`` logically represents a single bit of data, but no restrictions or suggestions are made for how an implementation should choose to store a variable decalred as a scalar bit.
+The scalar type ``bit`` logically represents a single bit of data, but no restrictions or suggestions are made for how an implementation should choose to store a variable declared as a scalar bit.
 The type ``bit[n]`` behaves as if it is stored in memory as a contiguous bit-packed sequence; this is reflected in its casting rules to and from the other types.
 There are no defined semantics for how ``bit`` or ``bit[n]`` types should behave if used for a parameter or return value in an ``extern`` call that implies an FFI call, and it is discouraged for implementations to allow this.
 Neither scalar ``bit``\ s nor ``bit[n]`` registers can be the base type of an ``array``.

--- a/spec_releasenotes/releasenotes/notes/bit-bool-equivalence-9c71bedb95b67c30.yaml
+++ b/spec_releasenotes/releasenotes/notes/bit-bool-equivalence-9c71bedb95b67c30.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    The types ``bool`` and (scalar) ``bit`` are now explicitly described as being completely
+    interchangeable in expression (r-value) positions, and that ``bit`` and ``bit[1]`` are distinct
+    types.  The difference between the types ``bool`` and ``bit`` is only in their intended storage
+    mechanisms; ``bit`` is the scalar of the register-type ``bit[n]``, which is explicitly a
+    bit-packed type, so cannot be used as the base type of an ``array``, while ``bool`` is a
+    byte-aligned single-bit integer-like type.  ``bit[1]`` is a register (sequence) type that
+    happens to be of length one.

--- a/spec_releasenotes/releasenotes/notes/no-qubit-array-743737a4f96b3bb0.yaml
+++ b/spec_releasenotes/releasenotes/notes/no-qubit-array-743737a4f96b3bb0.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    The ``qubit`` type is no longer a valid base type for an ``array``, and it is no longer stated
+    that the register type ``qubit[n]`` is equivalent to an ``array``; there is no need for these
+    semantics, and they clashed with the classical considerations and alignment concerns of arrays
+    in general.


### PR DESCRIPTION
### Summary

This formalises the idea that `bit[n]` is a sequence-like type of which `bit[1]` is just the length-one variant.  This is distinct from the type `bit`, which is the scalar of it.  The `bit[n]` type is expected to be stored bit-packed (certainly when used in expression positions), which is reflected in how it casts to other integer types.

Taken alone, it is fairly meaningless to attempt to have a "bit-aligned" scalar type `bit`.  We don't attempt to define semantics for this in any sort ABI for OpenQASM 3; the only places this would be observable from within the program are in `array` and in `extern` calls, both of which it is forbidden from appearing in.  Instead, the semantics of scalar bit are simply set to have `bit` and `bool` be interchangeable in r-value usage.

An additional line about `qubit[n]` being equivalent to `array[qubit, n]` is deleted here, since some of the motivation for the rest of this commit is considering the alignment concerns of the `bit` and `bool` types; it doesn't really make sense to talk about classical alignment of a `qubit` type, and there doesn't appear to be any need to allow `array[qubit, n]` when `qubit[n]` already suffices.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->


### Details and comments

Close #535
