### PR TITLE
Add extended gate syntax

### DIFF
--- a/.github/workflows/tests-ast.yml
+++ b/.github/workflows/tests-ast.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         # Just using minimum and maximum to avoid exploding the matrix.
-        python-version: ['3.7', '3.12']
+        python-version: ['3.9', '3.12']
         antlr-version: ['4.7', '4.13']
     defaults:
       run:

--- a/.github/workflows/tests-ast.yml
+++ b/.github/workflows/tests-ast.yml
@@ -14,9 +14,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Just using minimum and maximum to avoid exploding the matrix.
-        python-version: ['3.9', '3.12']
-        antlr-version: ['4.7', '4.13']
+        include:
+          # Build on the oldest and latest supported Pythons
+          # and on the oldest and latest ANTLR version supported
+          # by each of those Pythons:
+          - python-version: '3.9'
+            antlr-version: '4.7'
+          - python-version: '3.9'
+            antlr-version: '4.13'
+          - python-version: '3.13'
+            antlr-version: '4.9'
+          - python-version: '3.13'
+            antlr-version: '4.13'
     defaults:
       run:
         working-directory: source/openqasm

--- a/ast_releasenotes/releasenotes/notes/extended-gate-syntax-15b2f58b731db7e4.yaml
+++ b/ast_releasenotes/releasenotes/notes/extended-gate-syntax-15b2f58b731db7e4.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Introduces a new ast node type ``QuantumExtendedGateDefinition``` where the arguments
+    are ``List[ClassicalType]`` instead of ``List[Indentifier]``. A new node type was
+    introduced in order to avoid breaking backward compatibility with prior versions of
+    the reference parser. Consumers of the AST should now check for this new node type in
+    addition to the previously existing ``QuantumGateDefinition``.

--- a/source/grammar/qasm3Parser.g4
+++ b/source/grammar/qasm3Parser.g4
@@ -106,7 +106,7 @@ quantumDeclarationStatement: qubitType Identifier SEMICOLON;
 // Declarations and definitions of higher-order objects.
 defStatement: DEF Identifier LPAREN argumentDefinitionList? RPAREN returnSignature? scope;
 externStatement: EXTERN Identifier LPAREN externArgumentList? RPAREN returnSignature? SEMICOLON;
-gateStatement: GATE Identifier (LPAREN params=identifierList? RPAREN)? qubits=identifierList scope;
+gateStatement: GATE Identifier (LPAREN params=gateParameterList? RPAREN)? qubits=identifierList scope;
 
 // Non-declaration assignments and calculations.
 assignmentStatement: indexedIdentifier op=(EQUALS | CompoundAssignmentOperator) (expression | measureExpression) SEMICOLON;
@@ -220,11 +220,17 @@ argumentDefinition:
     | (CREG | QREG) Identifier designator?
     | arrayReferenceType Identifier
 ;
+gateParameter:
+    Identifier
+    | scalarType Identifier
+    | CREG Identifier designator?
+;
 
 argumentDefinitionList: argumentDefinition (COMMA argumentDefinition)* COMMA?;
 defcalArgumentDefinitionList: defcalArgumentDefinition (COMMA defcalArgumentDefinition)* COMMA?;
 defcalOperandList: defcalOperand (COMMA defcalOperand)* COMMA?;
 expressionList: expression (COMMA expression)* COMMA?;
 identifierList: Identifier (COMMA Identifier)* COMMA?;
+gateParameterList: gateParameter (COMMA gateParameter)* COMMA?;
 gateOperandList: gateOperand (COMMA gateOperand)* COMMA?;
 externArgumentList: externArgument (COMMA externArgument)* COMMA?;

--- a/source/grammar/tests/reference/gate/quantum_gate.yaml
+++ b/source/grammar/tests/reference/gate/quantum_gate.yaml
@@ -15,7 +15,7 @@ reference: |
           gate
           test_gate
           (
-          identifierList
+          gateParameterList
             theta
           )
           identifierList

--- a/source/grammar/tests/reference/gate/quantum_gate.yaml
+++ b/source/grammar/tests/reference/gate/quantum_gate.yaml
@@ -16,7 +16,8 @@ reference: |
           test_gate
           (
           gateParameterList
-            theta
+            gateParameter
+              theta
           )
           identifierList
             a

--- a/source/language/gates.rst
+++ b/source/language/gates.rst
@@ -177,45 +177,31 @@ of the gate definition.
 
 .. code-block:: c
 
-   gate name(typedParams) : typedQargs
+   gate name(typedParams) qargs
    {
      body
    }
 
 The optional parameter list ``typedParams`` is a comma-separated list of variable
-parameters, which in this case must be provided with explicit type specifications.
-The list ``typedQargs`` is a comma-separated list of operands which are either individual
-qubits, or registers/arrays of qubits, where each is again provided with an explicit type
-specification.
-If there are no variable parameters, the parentheses are optional. At least
-one quantum operand is required, and the quantum operands
-must be immediately preceded by a ``:`` delimiter.
-The arguments in ``typedQargs`` can be indexed within the body
-of the gate definition if, and only if, it is a register or array of qubits.
+parameters, which in this case must be provided with explicit type specifications. The
+``qargs`` qubit arguments are unchanged compared to the simple syntax. If there are no
+variable parameters, the parentheses are optional. At least one quantum operand is
+required.
 
 .. code-block:: c
 
    // this is ok:
-   gate g(angle alpha, int k): qubit[3] a
+   gate g(angle alpha, int k) a, b, c
    {
-     U(0, 0, alpha) a[0];
-     U(0, 0, alpha/k) a[1];
-     U(0, 0, alpha/(k**2)) a[2];
+     U(0, 0, alpha) a;
+     U(0, 0, alpha/k) b;
+     U(0, 0, alpha/(k**2)) c;
    }
 
-   // this is also ok:
-   gate qutritX : qubit[2] a {
-     x a[1];
-     cx a[1], a[0];
-     cx a[0], a[1];
-   }
-
-   // this is invalid:
-   gate g(angle alpha, int k): qubit a
+   // this is invalid (cannot mix typed and untyped parameters):
+   gate g(angle alpha, k) a
    {
-     U(0, 0, alpha) a[0]; // not allowed to index an individual qubit operand
-     U(0, 0, alpha/k) a[1];
-     U(0, 0, alpha/(k**2)) a[2];
+     U(0, 0, alpha) a;
    }
 
 
@@ -240,27 +226,6 @@ To avoid infinite recursion, gates must be declared before use and
 cannot call themselves. The statement ``name(params) qargs;`` applies the gate,
 and the variable parameters ``params`` must have the appropriate type (or be expressions
 which can be implicitly cast to the appropriate type).
-
-The quantum operands of a ``gate`` invocation must have the appropriate types to the declaration of the ``gate``.
-There is one exception to this type-agreement condition: if a ``gate`` has one or more operands of type ``qubit``,
-the gate may instead act on some qubit register(s) *of identical size* for one or all of those operands,
-as described in :ref:`broadcasting section <broadcasting>`.
-This functionality extends also to any ``gate`` declared with the
-'general' form, so long as all operands which are given an explicit size in the declaration,
-are provided with arguments of the corresponding type.
-
-.. code-block:: c
-
-   gate g : qubit qb0, qubit qb1, qubit[5] qreg
-   {
-     // body
-   }
-   qubit a[2];
-   qubit b[2];
-   qubit c[5];
-   qubit d[10];
-   g a, b, c; // ok: performs "g a[0], b[0], c; g a[1], b[1], c;"
-   g a, b, d; // error! third operand expects a register of size 5, not 10
 
 
 Quantum gate modifiers

--- a/source/language/gates.rst
+++ b/source/language/gates.rst
@@ -217,7 +217,7 @@ and these symbols are scoped only to the subroutine body.
 
 An empty body corresponds to the identity gate.
 
-While the 'general' gate syntax allows for non-``angle`` parameters, OpenQASM current does
+While the 'general' gate syntax allows for non-``angle`` parameters, OpenQASM currently does
 not permit **use** of these parameters within the body of the ``gate``. The additional
 type flexibility is intended to only be interpretted by corresponding ``defcal``
 definitions that may have a way to use such non-``angle`` parameters.

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -29,6 +29,10 @@ instruction sequence on *physical* qubits, e.g.
    defcal measure $0 -> bit { ... }
    defcal measure_iq q -> complex[float[32]] { ... }
 
+Note that this syntax is something of a hybrid between the 'short' and 'general' forms of
+``gate`` definitions in that type specifiers are **required** for parameters but that no
+semicolon appears between the classical parameters and the quantum arguments.
+
 We distinguish gate and measurement definitions by the presence of a
 return value type in the latter case, analogous to the subroutine syntax
 defined earlier. Furthermore, the return value type does not need to return a
@@ -94,6 +98,17 @@ Users specify the grammar used inside ``defcal`` blocks with a
 .. code-block::
 
    defcalgrammar "openpulse";
+
+The 'general' gate syntax allows for non-``angle`` parameters. While such parameters may
+not be used in the body of ``gate`` defintions, they **may** be used in corresponding
+``defcal`` statements. For example,
+
+.. code-block::
+
+   gate var_amp_x(float amplitude): qubit q { x q; }
+   defcal var_amp_x(float amplitude) $0 {
+      // implement an x gate using the specified control amplitude ...
+   }
 
 Note that ``defcal`` and ``gate`` communicate orthogonal information to the compiler. ``gate``\s
 define unitary transformation rules to the compiler. The compiler may

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -29,9 +29,8 @@ instruction sequence on *physical* qubits, e.g.
    defcal measure $0 -> bit { ... }
    defcal measure_iq q -> complex[float[32]] { ... }
 
-Note that this syntax is something of a hybrid between the 'short' and 'general' forms of
-``gate`` definitions in that type specifiers are **required** for parameters but that no
-semicolon appears between the classical parameters and the quantum arguments.
+Note that this syntax mirrors the 'general' form of ``gate`` definitions in that type
+specifiers are **required** for parameters.
 
 We distinguish gate and measurement definitions by the presence of a
 return value type in the latter case, analogous to the subroutine syntax
@@ -105,7 +104,7 @@ not be used in the body of ``gate`` defintions, they **may** be used in correspo
 
 .. code-block::
 
-   gate var_amp_x(float amplitude): qubit q { x q; }
+   gate var_amp_x(float amplitude) q { x q; }
    defcal var_amp_x(float amplitude) $0 {
       // implement an x gate using the specified control amplitude ...
    }

--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -204,7 +204,7 @@ class QubitDeclaration(Statement):
 @dataclass
 class QuantumGateDefinition(Statement):
     """
-    Define a new quantum gate
+    Define a new quantum gate with the simple syntax
 
     Example::
 
@@ -216,6 +216,25 @@ class QuantumGateDefinition(Statement):
 
     name: Identifier
     arguments: List[Identifier]
+    qubits: List[Identifier]
+    body: List[QuantumStatement]
+
+
+@dataclass
+class QuantumExtendedGateDefinition(Statement):
+    """
+    Define a new quantum gate with the extended syntax
+
+    Example::
+
+        gate rzz(angle theta) c, t {
+            // ...
+        }
+
+    """
+
+    name: Identifier
+    arguments: List[ClassicalArgument]
     qubits: List[Identifier]
     body: List[QuantumStatement]
 

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -175,7 +175,7 @@ def test_non_integer_physical_qubit_raises():
     p = """
     barrier $a;
     """.strip()
-    with pytest.raises(QASM3ParsingError, match="token recognition error at: '\$a'"):
+    with pytest.raises(QASM3ParsingError, match=r"token recognition error at: '\$a'"):
         parse(p)
 
 

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -59,6 +59,7 @@ from openqasm3.ast import (
     QuantumArgument,
     QuantumGate,
     QuantumGateDefinition,
+    QuantumExtendedGateDefinition,
     QuantumGateModifier,
     QuantumMeasurement,
     QuantumMeasurementStatement,
@@ -616,6 +617,48 @@ gate rz(λ) a { gphase(-λ/2); U(0, 0, λ) a; }
     assert gate_declaration.span == Span(1, 0, 1, 43)
     assert gate_declaration.arguments[0].span == Span(1, 8, 1, 8)
     assert gate_declaration.qubits[0].span == Span(1, 11, 1, 11)
+
+
+
+def test_gate_definition4():
+    p = """
+gate rx(angle theta) a { h a; rz(theta) a; h a; }
+    """.strip()
+    program = parse(p)
+    assert _remove_spans(program) == Program(
+        statements=[
+            QuantumExtendedGateDefinition(
+                name=Identifier("rx"),
+                arguments=[ClassicalArgument(type=AngleType(), name=Identifier(name="theta"))],
+                qubits=[Identifier(name="a")],
+                body=[
+                    QuantumGate(
+                        modifiers=[],
+                        name=Identifier("h"),
+                        arguments=[],
+                        qubits=[Identifier(name="a")],
+                    ),
+                    QuantumGate(
+                        modifiers=[],
+                        name=Identifier("rz"),
+                        arguments=[Identifier(name="theta")],
+                        qubits=[Identifier(name="a")],
+                    ),
+                    QuantumGate(
+                        modifiers=[],
+                        name=Identifier("h"),
+                        arguments=[],
+                        qubits=[Identifier(name="a")],
+                    )
+                ],
+            )
+        ]
+    )
+    SpanGuard().visit(program)
+    gate_declaration = program.statements[0]
+    assert gate_declaration.span == Span(1, 0, 1, 48)
+    assert gate_declaration.arguments[0].span == Span(1, 8, 1, 14)
+    assert gate_declaration.qubits[0].span == Span(1, 21, 1, 21)
 
 
 def test_gate_calls():

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -619,7 +619,6 @@ gate rz(λ) a { gphase(-λ/2); U(0, 0, λ) a; }
     assert gate_declaration.qubits[0].span == Span(1, 11, 1, 11)
 
 
-
 def test_gate_definition4():
     p = """
 gate rx(angle theta) a { h a; rz(theta) a; h a; }
@@ -649,7 +648,7 @@ gate rx(angle theta) a { h a; rz(theta) a; h a; }
                         name=Identifier("h"),
                         arguments=[],
                         qubits=[Identifier(name="a")],
-                    )
+                    ),
                 ],
             )
         ]

--- a/spec_releasenotes/releasenotes/notes/extended-gate-syntax-17b4aa46b48e3198.yaml
+++ b/spec_releasenotes/releasenotes/notes/extended-gate-syntax-17b4aa46b48e3198.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Added an extended ``gate`` syntax with typed classical parameters, connecting to
+    non-angle types allowed in ``defcal`` statements, and improving consistency with
+    use of types in other parts of the language.


### PR DESCRIPTION
This is intended to address #547. What I have done is copy over the extended gate syntax from #346. My intention is to add further changes to the `defcal` syntax that references using non-`angle` parameters within `defcals`.
