### PR TITLE
Docs/minor fixes

### DIFF
--- a/source/_extensions/multifigure.py
+++ b/source/_extensions/multifigure.py
@@ -110,7 +110,7 @@ def visit_multifigure_item_html(self, node):
         MULTIFIGURE_HTML_ITEM_TAG,
         CLASS='figure-item',
         style=' '.join((
-            'max-height: 10rem;',
+            'max-height: 13rem;',
             'width: %i%%;' % node.get('item-width'),
             'display: flex;',
             'flex-direction: column;'))

--- a/source/grammar/index.rst
+++ b/source/grammar/index.rst
@@ -1,7 +1,7 @@
-OpenQasm 3.0 Grammar
+OpenQASM 3.0 Grammar
 ====================
 
-OpenQasm 3.0 Grammar specification based in ANTLR_ parser generator.
+OpenQASM 3.0 Grammar specification based in ANTLR_ parser generator.
 
 The ANTLR grammar is intended to serve as the official reference grammar for OpenQASM3 and defines
 the set of syntactically valid statements in the language. ANTLR is used because it provides a

--- a/source/intro.rst
+++ b/source/intro.rst
@@ -41,11 +41,12 @@ Version 3.0 of the OpenQASM specification aims to extend OpenQASM to include:
 Scope
 -----
 
-This document aims to define the OpenQASM language itself, but it does not attempt to fully explain
-the motivation for various design choices. A forthcoming paper will provide this background. This
-document also does not seek to define the execution environment that accepts OpenQASM as an input.
-For the previous versions of OpenQASM please read arXiv:1707.03429_.
+This document defines the OpenQASM language specification while the motivation behind 
+its design choices is discussed in detail in arXiv:2104.14722_. Furthermore, the 
+specification does not define the execution environment that accepts OpenQASM as input. 
+For information about previous versions of OpenQASM, please refer to arXiv:1707.03429_.
 
+.. _arXiv:2104.14722: https://arxiv.org/abs/2104.14722
 .. _arXiv:1707.03429: https://arxiv.org/abs/1707.03429
 
 Implementation Details

--- a/source/language/index.rst
+++ b/source/language/index.rst
@@ -12,10 +12,7 @@ Statements are separated by semicolons and whitespace is ignored.
 In other respects, OpenQASM possesses a dual nature as an assembly language and
 as a hardware description language.
 
-Appendix `[app:summary] <#app:summary>`__ summarizes the
-language statements, Appendix `[app:grammar] <#app:grammar>`__ specifies
-the grammar, and Appendix `[app:semantics] <#app:semantics>`__ gives formal
-semantics.
+The OpenQASM grammar specifications can be found at `[OpenQASM 3.0 Grammar] <../grammar/index.html>`__.
 
 .. toctree::
 

--- a/source/language/openpulse.rst
+++ b/source/language/openpulse.rst
@@ -1,7 +1,7 @@
 OpenPulse Grammar
 =================
 
-*The OpenPulse grammar is still in active development and is liable to change. If you are working on an implementation and find this specification unclear or not supporting your use-cases, please join our community effort to improve pulse-level support in OpenQasm.*
+*The OpenPulse grammar is still in active development and is liable to change. If you are working on an implementation and find this specification unclear or not supporting your use-cases, please join our community effort to improve pulse-level support in OpenQASM.*
 
 OpenQASM allows users to provide the target system's implementation of quantum operations
 with ``cal`` and ``defcal`` blocks . Calibration grammars are open to extension for system implementors. In


### PR DESCRIPTION
### Summary
This PR fixes the documentation-related issues #560 (missing arXiv link), #561 (broken appendix links), and #562 (Figure overflow)

### Details

#### 1. Missing arXiv link (#560)
The [Introduction page](https://openqasm.com/intro.html#scope) refers to a forthcoming paper that will discuss the motivation behind the OpenQASM3 language specifications, even though the paper has already been released.  
**Fix**: Rewrote "Scope" section to include link to arXiv paper arXiv:2104.14722


#### 2. Broken appendix links (#561)
The [Language page](https://openqasm.com/language/index.html) contains three references to appendices `summary`, `grammar`, and `semantics`. All three links seem to be broken, and I was only able to locate the `grammar` appendix page. Have the other two pages been removed?  
**Fix**: Removed `summary` and `semantics` links, modified `grammar` link.

#### 3. Figure overflow (#562)
The [Built-in quantum instructions](https://openqasm.com/language/insts.html#measurement) contains two figures. In the last figure, the bottom middle subfigure overflows into the caption. This issue seems to be specific to chromium-based browsers as it could not be reproduced by @hodgestar using Firefox, nor locally using Safari. It would be good if someone could independently verify this using Chrome.  
**Fix**: Slightly increase max figure height.

#### Bonus: Rename `OpenQasm` → `OpenQASM`
I found two instances of `OpenQasm` (no capitalized `ASM`).  
**Fix**: Rename `OpenQasm` → `OpenQASM`.