### PR TITLE
Recommend namespacing pragmas and annotations

### DIFF
--- a/ast_releasenotes/releasenotes/notes/namespaces-for-pragmas-and-annotations-96194a38498e1c0c.yaml
+++ b/ast_releasenotes/releasenotes/notes/namespaces-for-pragmas-and-annotations-96194a38498e1c0c.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    Updates the annotations keyword to allow it to contain a dotted
+    list of identifiers rather than a single identifier. This change
+    is to support the specification update recommending that pragmas
+    and annotations be prefixed with namespaces.

--- a/source/grammar/qasm3Lexer.g4
+++ b/source/grammar/qasm3Lexer.g4
@@ -38,7 +38,7 @@ CASE: 'case';
 DEFAULT: 'default';
 
 PRAGMA: '#'? 'pragma' -> pushMode(EAT_TO_LINE_END);
-AnnotationKeyword: '@' Identifier ->  pushMode(EAT_TO_LINE_END);
+AnnotationKeyword: '@' Identifier ('.' Identifier)* ->  pushMode(EAT_TO_LINE_END);
 
 
 /* Types. */

--- a/source/language/directives.rst
+++ b/source/language/directives.rst
@@ -1,20 +1,50 @@
 Directives
 ==========
 
-OpenQASM supports directive mechanisms that allows other information to
+OpenQASM supports directive mechanisms that allow other information to
 be included in the program. Directives are either pragmas or annotations.
 Both are used to supply additional information to the compiler passes and the
 target system or simulator. Ideally the meaning of the program does not change
 if some or all of the directives are ignored, so they can be interpreted
 at the discretion of the consuming process.
 
+Pragma and annotation namespacing
+---------------------------------
+
+It is intended that different implementators of the specification might
+define their own pragmas and annotations. This creates the possibility that
+different implementations might define pragmas or annotations that collide.
+
+To avoid such collisions we recommend that implementations namespace their
+pragmas and annotations as follows:
+
+- Pragmas start with `pragma <namespace>.<name>(.<name>)*`.
+- Annotations start with `@<namespace>.<name>(.<name>)*`.
+
+Where `namespace` and `name` are valid OpenQASM identifiers.
+
+If the pragma or annotation takes additional arguments the
+final `<name>` should be followed by a single space before the
+additional text.
+
+The namespace should be a short name that identifies the organization that
+defines behaviour of the pragmas and annotations contained within it.
+
+The namespace `openqasm` is reserved for future use by the OpenQASM
+specification.
+
+
 Pragmas
 -------
 
 Pragma directives start with ``pragma`` and continue to the end of line. The
 text after ``pragma`` is a single string, and parsing is left to the specific
-implementation. Implementations may optionally choose to support the older ``#pragma``
-keyword as a custom extension.
+implementation, although implementors are encourage to use the namespacing
+described above.
+
+Implementations may optionally choose to support the older ``#pragma`` keyword
+as a custom extension.
+
 Pragmas should be processed as soon as they are encountered; if a
 pragma is not supported by a compiler pass it should be ignored and preserved
 intact for future passes.  Pragmas should avoid stateful or positional
@@ -30,7 +60,7 @@ documentation for supported pragmas.
 
 .. code-block::
 
-   pragma simulator noise model "qpu1.noise"
+   pragma qiskit.simulator noise model "qpu1.noise"
 
 Pragmas can also be used to specify system-level information or assertions for
 the entire circuit.
@@ -40,10 +70,10 @@ the entire circuit.
    OPENQASM 3.0;
 
    // Attach billing information
-   pragma user alice account 12345678
+   pragma ibmq.user alice account 12345678
 
    // Assert that the QPU is healthy to run this circuit
-   pragma max_temp qpu 0.4
+   pragma ibmq.max_temp qpu 0.4
 
    qubit[2] q;
 
@@ -53,7 +83,8 @@ Annotations
 
 Annotations can be added to supply additional information to the following
 OpenQASM ``statement`` as defined in the grammar. Annotations will start with a
-``@`` symbol, have an identifying keyword and continue to the end of the line.
+``@`` symbol, have a dotted list of identifying keywords and continue to the end
+of the line.
 
 Multiple annotations may be added to a single statement. No ordering or
 interaction between annotations are prescribed by this specification.
@@ -69,21 +100,21 @@ documentation for supported annotations.
    input bit[2] control_flags;
 
    // Instruct compiler to create a reversible version of the function
-   @reversible
+   @openqasm.reversible
    gate multiply a, b, x {
       x = a * b;
    }
 
    // Prevent swap insertion
-   @noswap
+   @openqasm.noswap
    box {
       rx(pi) q[0];
       cnot q[0], q[3];
    }
 
    // Apply multiple annotations
-   @crosstalk
-   @noise profile "gate_noise.qnf"
+   @openqasm.crosstalk
+   @openqasm.noise profile "gate_noise.qnf"
    defcal noisy_gate $0 $1 { ... }
 
 

--- a/source/language/directives.rst
+++ b/source/language/directives.rst
@@ -73,7 +73,7 @@ the entire circuit.
    pragma ibm.user alice account 12345678
 
    // Assert that the QPU is healthy to run this circuit
-   pragma ibmq.max_temp qpu 0.4
+   pragma ibm.max_temp qpu 0.4
 
    qubit[2] q;
 

--- a/source/language/directives.rst
+++ b/source/language/directives.rst
@@ -70,7 +70,7 @@ the entire circuit.
    OPENQASM 3.0;
 
    // Attach billing information
-   pragma ibmq.user alice account 12345678
+   pragma ibm.user alice account 12345678
 
    // Assert that the QPU is healthy to run this circuit
    pragma ibmq.max_temp qpu 0.4

--- a/source/openqasm/tests/test_printer.py
+++ b/source/openqasm/tests/test_printer.py
@@ -566,6 +566,7 @@ duration a = durationof({
         input_ = """
 pragma blah blah blah
 pragma command
+pragma namespace.command
 pragma !%^* word
 """.lstrip()  # The ending newline is important for pragmas.
         output = openqasm3.dumps(openqasm3.parse(input_))
@@ -578,6 +579,8 @@ pragma !%^* word
             pytest.param("@command keyword\n", id="single keyword"),
             pytest.param("@command !£4&8 hello world\n", id="hard to tokenise"),
             pytest.param("@command1\n@command2 keyword\n", id="multiple"),
+            pytest.param("@namespace.command1 keyword\n", id="dotted"),
+            pytest.param("@namespace.foo.command1\n", id="multi-dotted"),
         ]
     )
     def annotations(self, request):

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -1795,6 +1795,9 @@ def test_annotations():
         @inner2 command
         x = 19;
     }
+
+    @namespace.name1.name2
+    gate my_gate_2 q {}
     """.strip()
     program = parse(p)
     assert _remove_spans(program) == Program(
@@ -1871,6 +1874,13 @@ def test_annotations():
                 ),
                 [Annotation(keyword="outer", command=None)],
             ),
+            # Namespaced annotations
+            _with_annotations(
+                QuantumGateDefinition(
+                    name=Identifier("my_gate_2"), arguments=[], qubits=[Identifier("q")], body=[]
+                ),
+                [Annotation(keyword="namespace.name1.name2", command=None)],
+            ),
         ],
     )
     SpanGuard().visit(program)
@@ -1880,8 +1890,10 @@ def test_pragma():
     p = """
     #pragma verbatim
     pragma verbatim
+    pragma openqasm.verbatim
     #pragma command arg1 arg2
     pragma command arg1 arg2
+    pragma openqasm.command arg1 arg2
     #pragma otherwise_invalid_token 1a2%&
     pragma otherwise_invalid_token 1a2%&
     """  # No strip because all line endings are important for pragmas.
@@ -1890,8 +1902,10 @@ def test_pragma():
         statements=[
             Pragma(command="verbatim"),
             Pragma(command="verbatim"),
+            Pragma(command="openqasm.verbatim"),
             Pragma(command="command arg1 arg2"),
             Pragma(command="command arg1 arg2"),
+            Pragma(command="openqasm.command arg1 arg2"),
             Pragma(command="otherwise_invalid_token 1a2%&"),
             Pragma(command="otherwise_invalid_token 1a2%&"),
         ]

--- a/spec_releasenotes/releasenotes/notes/namespaces-for-pragmas-and-annotations-9c36a93b0f14d0ad.yaml
+++ b/spec_releasenotes/releasenotes/notes/namespaces-for-pragmas-and-annotations-9c36a93b0f14d0ad.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Adds a recommendation that pragmas and annotations start with a namespaced
+    identifier to avoid naming collisions between pragmas and annotations
+    specified by different implementations.
+    To support namespaced annotations, the annotations keyword may now include
+    a dotted ('.') list of identifiers.


### PR DESCRIPTION
### Summary

This adds a recommendation to the directives specification suggesting that implementations namespace their pragmas and annotations to avoid collisions.

It reserves the use of the `openqasm` namespace for future use by the OpenQASM specification.

It extends the allowed annotations keywords to allow a dotted list of identifiers rather than a single identifier. At the cost of adjusting the parser to be a little more permissive, this allows pragmas and annotations to use identically namespacing that follows common conventions (e.g. Java and Python import namespacing). Using dot as the name separator allows underscore to be used within a name to separate words.

### Details and comments

Questions:

- Are we happy with extending the allowed annotation keywords as described? Does this require an OpenQASM specification version bump?
- Are we happy with the examples in the specification? I wasn't sure whether using `ibm.` was appropriate, but I also didn't want to make the examples too abstract.
- I would like to maintain a table of known namespaces, but the specification itself didn't feel like the correct place. Should I create a file somewhere else? If so, where? Or just add a small table to the specification for now?


