### PR TITLE
Update black to 24.10.

### DIFF
--- a/.github/workflows/tests-ast.yml
+++ b/.github/workflows/tests-ast.yml
@@ -23,7 +23,7 @@ jobs:
             - python-version: '3.9'
               antlr-version: '4.13'
             - python-version: '3.13'
-              antlr-version: '4.8'
+              antlr-version: '4.9'
             - python-version: '3.13'
               antlr-version: '4.13'
     defaults:

--- a/.github/workflows/tests-ast.yml
+++ b/.github/workflows/tests-ast.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         # Just using minimum and maximum to avoid exploding the matrix.
-        python-version: ['3.7', '3.12']
+        python-version: ['3.9', '3.13']
         antlr-version: ['4.7', '4.13']
     defaults:
       run:

--- a/.github/workflows/tests-ast.yml
+++ b/.github/workflows/tests-ast.yml
@@ -14,9 +14,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Just using minimum and maximum to avoid exploding the matrix.
-        python-version: ['3.9', '3.13']
-        antlr-version: ['4.7', '4.13']
+        include:
+            # Build on the oldest and latest supported Pythons
+            # and on the oldest and latest ANTLR version supported
+            # by each of those Pythons:
+            - python-version: '3.9'
+              antlr-version: '4.7'
+            - python-version: '3.9'
+              antlr-version: '4.13'
+            - python-version: '3.13'
+              antlr-version: '4.8'
+            - python-version: '3.13'
+              antlr-version: '4.13'
     defaults:
       run:
         working-directory: source/openqasm

--- a/source/openqasm/docs/conf.py
+++ b/source/openqasm/docs/conf.py
@@ -3,9 +3,9 @@
 
 import openqasm3
 
-project = 'OpenQASM 3 Reference AST'
-copyright = '2021, OpenQASM 3 Team and Contributors'
-author = 'OpenQASM 3 Team and Contributors'
+project = "OpenQASM 3 Reference AST"
+copyright = "2021, OpenQASM 3 Team and Contributors"
+author = "OpenQASM 3 Team and Contributors"
 release = openqasm3.__version__
 
 extensions = [
@@ -14,6 +14,6 @@ extensions = [
     "sphinx.ext.autodoc",
 ]
 
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
-html_theme = 'alabaster'
+html_theme = "alabaster"

--- a/source/openqasm/openqasm3/printer.py
+++ b/source/openqasm/openqasm3/printer.py
@@ -52,7 +52,6 @@ state object is mutated by the visit, and will reflect the output state at the e
     :members:
 """
 
-
 import contextlib
 import dataclasses
 import io

--- a/source/openqasm/pyproject.toml
+++ b/source/openqasm/pyproject.toml
@@ -3,4 +3,4 @@ requires = ["setuptools", "wheel"]
 
 [tool.black]
 line-length = 100
-target-version = ["py37", "py38", "py39", "py310", "py311", "py312"]
+target-version = ["py37", "py38", "py39", "py310", "py311", "py312", "py313"]

--- a/source/openqasm/requirements-dev.txt
+++ b/source/openqasm/requirements-dev.txt
@@ -5,4 +5,4 @@ Sphinx>=4.0
 
 # Black uses calver majors for changes to the default style;
 # we can allow updates within a given year.
-black~=23.1
+black~=24.10


### PR DESCRIPTION
### Summary

We had a dependabot alert to update black and its probably a little overdue in any case.

### Details and comments

The new black version made minor changes to:

- `source/openqasm/docs/conf.py`
- `source/openqasm/openqasm3/printer.py`

but no significant churn.

