### PR TITLE
(Draft) Implement `extern` Identifiers

### DIFF
--- a/source/grammar/qasm3Parser.g4
+++ b/source/grammar/qasm3Parser.g4
@@ -31,6 +31,7 @@ statement:
         | delayStatement
         | endStatement
         | expressionStatement
+        | externIdentifier
         | externStatement
         | forStatement
         | gateCallStatement
@@ -105,6 +106,7 @@ quantumDeclarationStatement: qubitType Identifier SEMICOLON;
 
 // Declarations and definitions of higher-order objects.
 defStatement: DEF Identifier LPAREN argumentDefinitionList? RPAREN returnSignature? scope;
+externIdentifier: EXTERN externType Identifier SEMICOLON;
 externStatement: EXTERN Identifier LPAREN externArgumentList? RPAREN returnSignature? SEMICOLON;
 gateStatement: GATE Identifier (LPAREN params=identifierList? RPAREN)? qubits=identifierList scope;
 
@@ -206,6 +208,8 @@ scalarType:
 qubitType: QUBIT designator?;
 arrayType: ARRAY LBRACKET scalarType COMMA expressionList RBRACKET;
 arrayReferenceType: (READONLY | MUTABLE) ARRAY LBRACKET scalarType COMMA (expressionList | DIM EQUALS expression) RBRACKET;
+/* This should be overridden by defcalgrammars */
+externType: VOID;
 
 designator: LBRACKET expression RBRACKET;
 

--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -54,6 +54,7 @@ __all__ = [
     "ExpressionStatement",
     "ExternArgument",
     "ExternDeclaration",
+    "ExternIdentifier",
     "FloatLiteral",
     "FloatType",
     "ForInLoop",
@@ -96,6 +97,7 @@ __all__ = [
     "UnaryExpression",
     "UnaryOperator",
     "WhileLoop",
+    "VoidType",
 ]
 
 AccessControl = Enum("AccessControl", "readonly mutable")
@@ -243,6 +245,17 @@ class ExternDeclaration(Statement):
     arguments: List[ExternArgument]
     return_type: Optional[ClassicalType] = None
 
+
+@dataclass
+class ExternIdentifier(Statement):
+    """
+    A extern identifier. The types are to be defined by the defcalgrammar.
+    
+    Example::
+        extern void var;
+    """
+    type: ClassicalType
+    name: Identifier
 
 class Expression(QASMNode):
     """An expression: anything that returns a value"""
@@ -684,6 +697,11 @@ class ConstantDeclaration(Statement):
 class ClassicalType(QASMNode):
     """
     Base class for classical type
+    """
+
+class VoidType(ClassicalType):
+    """
+    Node representing a classical ``void`` type.
     """
 
 

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -384,6 +384,15 @@ class QASMNodeVisitor(qasm3ParserVisitor):
         )
 
     @span
+    def visitExternIdentifier(self, ctx: qasm3Parser.ExternIdentifierContext):
+        if not self._in_global_scope():
+            _raise_from_context(ctx, "extern identifiers must be global")
+        return ast.ExternIdentifier(
+            type=self.visit(ctx.externType()),
+            name=_visit_identifier(ctx.Identifier())
+        )
+
+    @span
     def visitForStatement(self, ctx: qasm3Parser.ForStatementContext):
         if ctx.setExpression():
             set_declaration = self.visit(ctx.setExpression())
@@ -840,6 +849,12 @@ class QASMNodeVisitor(qasm3ParserVisitor):
             base_type=base,
             dimensions=dimensions,
         )
+
+    @span
+    def visitExternType(self, ctx: qasm3Parser.ExternTypeContext):
+        if ctx.VOID():
+            return ast.VoidType()
+        _raise_from_context(ctx, "unhandled type: {ctx.getText()}")
 
     @span
     def visitGateOperand(self, ctx: qasm3Parser.GateOperandContext):

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -39,6 +39,7 @@ from openqasm3.ast import (
     ExpressionStatement,
     ExternArgument,
     ExternDeclaration,
+    ExternIdentifier,
     FloatLiteral,
     FloatType,
     ForInLoop,
@@ -75,9 +76,11 @@ from openqasm3.ast import (
     UintType,
     UnaryExpression,
     UnaryOperator,
+    VoidType,
 )
 from openqasm3.parser import parse, QASM3ParsingError
 from openqasm3.visitor import QASMVisitor
+
 
 
 def _with_annotations(node, annotations):
@@ -465,6 +468,7 @@ def test_extern_declarations():
     extern f(bool);
     extern f(int[32], uint[32]);
     extern f(mutable array[complex[float[64]], N_ELEMENTS]) -> int[2 * INT_SIZE];
+    extern void var;
     """.strip()
     program = parse(p)
     assert _remove_spans(program) == Program(
@@ -509,6 +513,10 @@ def test_extern_declarations():
                         rhs=Identifier(name="INT_SIZE"),
                     )
                 ),
+            ),
+            ExternIdentifier(
+                type=VoidType(),
+                name=Identifier("var")
             ),
         ]
     )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Implements #577 

### Details and comments

Defcal grammar's allow the specification of externally linked resources, marked with the `extern` keyword. For example, OpenPulse allows declaring `extern port` or `extern frame` resources that are externally linked at compile time. However, the base grammar does not support such statements.

This commit adds a base parser rule for such externally linked resources.
