### PR TITLE
Release v1.0.1

### DIFF
--- a/ast_release.md
+++ b/ast_release.md
@@ -19,6 +19,7 @@ PyPI's authorisation policies may need us to change how we handle that in the fu
    Modify `/source/openqasm/ANTLR_VERSIONS.txt` if you want to add/remove versions.
 2. Make a PR to that branch that bumps the version numbers of the Python package to the desired value, if it isn't already.
    At the time of writing, the only place needing to be updated is `/source/openqasm/openqasm3/__init__.py:__version__`; everywhere else pulls that in dynamically.
+   You will likely need to add a release note (see also `CONTRIBUTING.md`).
 3. Tag the desired commit, most likely the version-bump one, as `ast-py/v<version>`.
    `<version>` must match the Python-package version string exactly (it's a sanity check in the CD pipeline).
    For example, if releasing version `0.5.0`, set the `__init__.py:__version__` attribute to `"0.5.0"`, and make the tag `ast-py/v0.5.0`.

--- a/ast_releasenotes/releasenotes/notes/update-ast-version-1.0.1-bd00cb34c30ebd30.yaml
+++ b/ast_releasenotes/releasenotes/notes/update-ast-version-1.0.1-bd00cb34c30ebd30.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    Update the `openqasm3` Python package version to 1.0.1.
+    

--- a/source/openqasm/openqasm3/__init__.py
+++ b/source/openqasm/openqasm3/__init__.py
@@ -25,7 +25,7 @@ __all__ = [
     "parse",
 ]
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 from . import ast, visitor, properties, spec
 

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -174,7 +174,7 @@ def test_non_integer_physical_qubit_raises():
     p = """
     barrier $a;
     """.strip()
-    with pytest.raises(QASM3ParsingError, match="token recognition error at: '\$a'"):
+    with pytest.raises(QASM3ParsingError, match=r"token recognition error at: '\$a'"):
         parse(p)
 
 


### PR DESCRIPTION
This PR cuts a release for 1.0.1 of the `openqasm3` Python library. There have been a few minor parser improvements in the past few months, so I figured it was worth a release.



