### PR TITLE
Fix formatting of `durationof` release note.

### DIFF
--- a/spec_releasenotes/releasenotes/notes/durationof-typo-9eef70f7ecadf734.yaml
+++ b/spec_releasenotes/releasenotes/notes/durationof-typo-9eef70f7ecadf734.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix a typo in a example of the `durationof` keyword.
+    Fix a typo in a example of the ``durationof`` keyword.


### PR DESCRIPTION
Need double back quotes for it to be formatted properly.