### PR TITLE
Remove ~= assignment operator.

### DIFF
--- a/ast_releasenotes/releasenotes/notes/remove-not-assignment-op-4e96bca529fa7b1c.yaml
+++ b/ast_releasenotes/releasenotes/notes/remove-not-assignment-op-4e96bca529fa7b1c.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Remove ambiguous and undocumented ``~=`` assignment operator from the grammar.

--- a/source/grammar/qasm3Lexer.g4
+++ b/source/grammar/qasm3Lexer.g4
@@ -122,7 +122,7 @@ TILDE: '~';
 EXCLAMATION_POINT: '!';
 
 EqualityOperator: '==' | '!=';
-CompoundAssignmentOperator: '+=' | '-=' | '*=' | '/=' | '&=' | '|=' | '~=' | '^=' | '<<=' | '>>=' | '%=' | '**=';
+CompoundAssignmentOperator: '+=' | '-=' | '*=' | '/=' | '&=' | '|=' | '^=' | '<<=' | '>>=' | '%=' | '**=';
 ComparisonOperator: '>' | '<' | '>=' | '<=';
 BitshiftOperator: '>>' | '<<';
 

--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -100,7 +100,7 @@ __all__ = [
 ]
 
 AccessControl = Enum("AccessControl", "readonly mutable")
-AssignmentOperator = Enum("AssignmentOperator", "= += -= *= /= &= |= ~= ^= <<= >>= %= **=")
+AssignmentOperator = Enum("AssignmentOperator", "= += -= *= /= &= |= ^= <<= >>= %= **=")
 BinaryOperator = Enum("BinaryOperator", "> < >= <= == != && || | ^ & << >> + - * / % **")
 GateModifierName = Enum("GateModifier", "inv pow ctrl negctrl")
 IOKeyword = Enum("IOKeyword", "input output")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Remove the `~=` assignment operator from the grammar/parser.

### Details and comments

`~=` is never mentioned in the spec, never used in any of the examples, nor does anyone seem to know what it is supposed to do in the first place ([Slack thread](https://qiskit.slack.com/archives/C02FQB4F1M3/p1693332903688269)). Removing it resolves the confusion that was the impetus for https://github.com/openqasm/openqasm/issues/478, but does not resolve the issue of assignment operator documentation itself.

