### PR TITLE
vqe.qasm: number of get_parameter's argument is 1

### DIFF
--- a/examples/vqe.qasm
+++ b/examples/vqe.qasm
@@ -14,7 +14,7 @@ const int[32] shots = 1000;   // number of shots per Pauli observable
 
 // Parameters could be written to local variables for this
 // iteration, but we will request them using extern functions
-extern get_parameter(uint[prec], uint[prec]) -> angle[prec];
+extern get_parameter(uint[prec]) -> angle[prec];
 extern get_npaulis() -> uint[prec];
 extern get_pauli(int[prec]) -> bit[2 * n];
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

updated vqe.qasm.

### Details and comments

get_parameter was declared as
```
extern get_parameter(uint[prec], uint[prec]) -> angle[prec];
```
but get_parameter was called as
```
theta = get_parameter(l * layers + i);
```

I fixed the declaration to
```
extern get_parameter(uint[prec]) -> angle[prec];
```