### PR TITLE
feat: Add error position info

### DIFF
--- a/ast_releasenotes/releasenotes/notes/add-error-position-info-8a5e0afd63c221ac.yaml
+++ b/ast_releasenotes/releasenotes/notes/add-error-position-info-8a5e0afd63c221ac.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Add parsing positional information (line, column) to 
+    `openqasm3.parser.QASM3ParsingError`.

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -64,6 +64,18 @@ class QASM3ParsingError(Exception):
     """An error raised by the AST visitor during the AST-generation phase.  This is raised in cases where the
     given program could not be correctly parsed."""
 
+    def __init__(self, message: str, line: int | None = None, column: int | None = None) -> None:
+        if line is not None and column is not None:
+            prefix = f"L{line}:C{column}: "
+        elif line is not None:
+            prefix = f"L{line}: "
+        else:
+            prefix = ""
+
+        super().__init__(f"{prefix}{message}")
+        self.line = line
+        self.column = column
+
 
 class _RaiseOnErrorListener(ErrorListener):
     """Raises exception for all errors handled by this listener."""
@@ -77,7 +89,7 @@ class _RaiseOnErrorListener(ErrorListener):
         msg: str,
         exc: RecognitionException,
     ):
-        raise QASM3ParsingError(f"L{line}:C{column}: {msg}") from exc
+        raise QASM3ParsingError(msg, line, column) from exc
 
 
 def parse(input_: str, *, permissive=False) -> ast.Program:
@@ -103,8 +115,10 @@ def parse(input_: str, *, permissive=False) -> ast.Program:
         lexer.addErrorListener(_RaiseOnErrorListener())
     try:
         tree = parser.program()
-    except (RecognitionException, ParseCancellationException) as exc:
-        raise QASM3ParsingError() from exc
+    except RecognitionException as exc:
+        raise QASM3ParsingError(exc.message) from exc
+    except ParseCancellationException as exc:
+        raise QASM3ParsingError("parse failed") from exc
     return QASMNodeVisitor().visitProgram(tree)
 
 
@@ -148,7 +162,7 @@ def _visit_identifier(identifier: TerminalNode):
 
 
 def _raise_from_context(ctx: ParserRuleContext, message: str):
-    raise QASM3ParsingError(f"L{ctx.start.line}:C{ctx.start.column}: {message}")
+    raise QASM3ParsingError(message, ctx.start.line, ctx.start.column)
 
 
 class QASMNodeVisitor(qasm3ParserVisitor):

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -33,7 +33,7 @@ __all__ = [
 ]
 
 from contextlib import contextmanager
-from typing import Union, TypeVar, List
+from typing import Union, TypeVar, List, Optional
 
 try:
     from antlr4 import CommonTokenStream, InputStream, ParserRuleContext, RecognitionException
@@ -64,7 +64,9 @@ class QASM3ParsingError(Exception):
     """An error raised by the AST visitor during the AST-generation phase.  This is raised in cases where the
     given program could not be correctly parsed."""
 
-    def __init__(self, message: str, line: int | None = None, column: int | None = None) -> None:
+    def __init__(
+        self, message: str, line: Optional[int] = None, column: Optional[int] = None
+    ) -> None:
         if line is not None and column is not None:
             prefix = f"L{line}:C{column}: "
         elif line is not None:
@@ -89,7 +91,7 @@ class _RaiseOnErrorListener(ErrorListener):
         msg: str,
         exc: RecognitionException,
     ):
-        raise QASM3ParsingError(msg, line, column) from exc
+        raise QASM3ParsingError(msg, line=line, column=column) from exc
 
 
 def parse(input_: str, *, permissive=False) -> ast.Program:

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -175,8 +175,10 @@ def test_non_integer_physical_qubit_raises():
     p = """
     barrier $a;
     """.strip()
-    with pytest.raises(QASM3ParsingError, match=r"token recognition error at: '\$a'"):
+    with pytest.raises(QASM3ParsingError, match=r"token recognition error at: '\$a'") as e_info:
         parse(p)
+    assert e_info.value.line == 1
+    assert e_info.value.column == len("barrier ")
 
 
 def test_integer_declaration():


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Update `openqasm3.parser.QASM3ParsingError` to include error position information

### Details and comments

* In #576 we added an error listener to raise the `QASM3ParserError`, however this PR forgot to propagate useful debugging information to the exception.
* This PR preserves line/column positional information in the exception object.
* Additionally, we delegates message formatting to the exception constructor; this will make it easier to maintain a standard message format (callers of the exception class don't have to worry about formatting).

