### PR TITLE
[spec] Clarify const vs non-const durations

### DIFF
--- a/source/language/delays.rst
+++ b/source/language/delays.rst
@@ -148,6 +148,23 @@ backend-specific externs).
        // stretchy duration with backtracking by up to half b
        stretch e = -0.5 * b + c;
 
+Because `stretch` introduces a `const duration`, initialization with a non-`const` expression are a type error. On the other hand, because stretch resolution requires solving a system of constraints, a compiler may reject a well-typed program involving stretch durations due to a failure to resolve the constraint system.
+
+.. code-block::
+
+       input duration a; // not const
+       const duration b = 300ns;
+       stretch c;
+
+       // type error: const initializer expected
+       stretch d = c + a;
+
+       // stretch resolution error: 'e' resolved to -200ns
+       stretch e = b - 500ns;
+       delay[e] q0;
+
+
+
 Delays (and other duration-based instructions)
 ----------------------------------------------
 

--- a/source/language/delays.rst
+++ b/source/language/delays.rst
@@ -47,11 +47,11 @@ Below are some examples of values of type ``duration``.
 .. code-block::
 
        // fixed duration, in standard units
-       duration a = 300ns;
+       const duration a = 300ns;
        // fixed duration, backend dependent
-       duration b = 800dt;
+       const duration b = 800dt;
        // fixed duration, referencing the duration of a calibrated gate
-       duration c = durationof({x $3;});
+       const duration c = durationof({x $3;});
 
 We further introduce a ``stretch`` declaration, which is a special
 syntax for introducing a ``const duration`` with an unspecified,

--- a/source/language/delays.rst
+++ b/source/language/delays.rst
@@ -23,7 +23,7 @@ Duration and stretch types
 ---------------------------
 
 The ``duration`` type is used denote increments of time. Durations are real numbers
-that are manipulated at compile time. Durations must be followed by time units which can be
+that are manipulated at compile or run time. Durations must be followed by time units which can be
 any of the following:
 
 -  SI units of time: ``ns, µs or us, ms, s``
@@ -38,7 +38,7 @@ It is often useful to reference the duration of other parts of the
 circuit. For example, we may want to delay a gate for twice the duration
 of a particular sub-circuit, without knowing the exact value to which
 that duration will resolve. Alternatively, we may want to calibrate a
-gate using some pulses, and use its duration as a new ``duration`` in order to delay
+gate using some pulses, and use its duration as a new ``const duration`` in order to delay
 other parts of the circuit. The ``durationof()`` intrinsic function can be used for this
 type of referential timing.
 
@@ -53,10 +53,11 @@ Below are some examples of values of type ``duration``.
        // fixed duration, referencing the duration of a calibrated gate
        duration c = durationof({x $3;});
 
-We further introduce a ``stretch`` type which is a sub-type of ``duration``. Stretchable durations
-have variable non-negative duration that are permitted to grow as necessary
-to satisfy constraints. Stretch variables are resolved at compile time
-into target-appropriate durations that satisfy a user’s specified design
+We further introduce a ``stretch`` declaration, which is a special
+syntax for introducing a ``const duration`` with an unspecified,
+non-negative duration value determined by constraints in the
+program. Stretch variables are resolved at compile time into
+target-appropriate durations that satisfy a user’s specified design
 intent.
 
 Instructions whose duration are specified in this way become “stretchy",
@@ -127,17 +128,20 @@ these side effects. Also contrary to TeX, we prohibit overlapping gates.
 Operations on durations
 -----------------------
 
-We can add/subtract two durations, or multiply or divide them by a constant, to get a new
-duration. Division of two durations results in a machine-precision float 
-(see :ref:`divideDuration`). Negative durations are allowed, however
-passing a negative duration to a ``gate[duration]`` or ``box[duration]`` expression will result in an error.
-All operations on durations happen at compile time since ultimately all
-durations, including stretches, will be resolved to constants.
+We can add/subtract two durations, or multiply or divide them by a
+constant, to get a new duration. Division of two durations results in
+a machine-precision float (see :ref:`divideDuration`). Negative
+durations are allowed, however passing a negative duration to a
+``gate[duration]`` or ``box[duration]`` expression will result in an
+error.  All operations on ``const`` durations, including stretches,
+can happen at compile time. Note that some programs may make use of
+non-const duration (e.g. as ``input`` parameters or in
+backend-specific externs).
 
 .. code-block::
 
-       duration a = 300ns;
-       duration b = durationof({x $0;});
+       const duration a = 300ns;
+       const duration b = durationof({x $0;});
        stretch c;
        // stretchy duration with min=300ns
        stretch d = a + 2 * c;
@@ -246,9 +250,9 @@ to properly take into account the finite duration of each gate.
 
    stretch a;
    stretch b;
-   duration start_stretch = a - .5 * durationof({x $0;});
-   duration middle_stretch = a - .5 * durationof({x $0;}) - .5 * durationof({y $0;});
-   duration end_stretch = a - .5 * durationof({y $0;});
+   const duration start_stretch = a - .5 * durationof({x $0;});
+   const duration middle_stretch = a - .5 * durationof({x $0;}) - .5 * durationof({y $0;});
+   const duration end_stretch = a - .5 * durationof({y $0;});
 
    delay[start_stretch] $0;
    x $0;

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -735,8 +735,8 @@ backend-dependent unit equivalent to one waveform sample.
 
 .. code-block::
 
-   duration one_second = 1000ms;
-   duration thousand_cycles = 1000dt;
+   const duration one_second = 1000ms;
+   const duration thousand_cycles = 1000dt;
 
 .. _types-arrays:
 
@@ -821,28 +821,33 @@ Types related to timing
 Duration
 ~~~~~~~~
 
-We introduce a ``duration`` type to express timing.
-Durations can be assigned with expressions including timing literals.
-``durationof()`` is an intrinsic function used to reference the
-duration of a calibrated gate.
+We introduce a ``duration`` type to express timing. Durations can be
+introduced with timing literals and generally manipulated at run time,
+though some language constructs (e.g. ``stretch``, described below)
+require that the durations involved be ``const``. To reference the
+duration of a calibrated gate, the ``durationof()`` operation returns
+a ``const duration``.
 
 .. code-block::
 
-   duration one_second = 1000ms;
-   duration thousand_cycles = 1000dt;
-   duration two_seconds = one_second + 1s;
-   duration c = durationof({x $3;});
+   const duration one_second = 1000ms;
+   const duration thousand_cycles = 1000dt;
+   const duration two_seconds = one_second + 1s;
+   const duration c = durationof({x $3;});
+
+   duration dvar = 0dt;
+   dvar += thousand_cycles;
 
 ``duration`` is further discussed in :any:`duration-and-stretch`
 
 Stretch
 ~~~~~~~
 
-We further introduce a ``stretch`` type which is a sub-type of ``duration``. ``stretch`` types
-have variable non-negative duration that is permitted to grow as necessary
-to satisfy constraints. Stretch variables are resolved at compile time
-into target-appropriate durations that satisfy a user’s specified design
-intent.
+We further introduce a ``stretch`` declaration which is a special
+syntax for introducing a ``const duration`` with an unspecified,
+non-negative duration value determined by constraints in the program.
+Stretch variables are resolved at compile time into target-appropriate
+duration constants that satisfy a user’s specified design intent.
 
 ``stretch`` is further discussed in :any:`duration-and-stretch`
 

--- a/spec_releasenotes/releasenotes/notes/clarify-const-durations-a363ee2db6baafb3.yaml
+++ b/spec_releasenotes/releasenotes/notes/clarify-const-durations-a363ee2db6baafb3.yaml
@@ -1,0 +1,4 @@
+---
+issues:
+  - |
+    Updated the spec to indicate that `durationof` returns a `const duration`.


### PR DESCRIPTION
My notes from the 8/20 TSC meeting mention a few spec clarifications for `duration`, namely

- durationof returns a const duration
- durations can be const or non-const
- stretch expressions can be rejected by the type-checker because they involve non-const durations
- but some stretch failures are only caught later at stretch resolution time due to unsolvable constraints

These are related to https://github.com/openqasm/openqasm/issues/617, though with some tweaks based on the TSC discussion. 