### PR TITLE
Clarify that sizeof() does not operate on registers.

### DIFF
--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -168,3 +168,8 @@ subscripted, meaning that ``sizeof(arr[0], 0) == sizeof(arr, 1)``.
      }
      // ...
    }
+
+Note that while bit and qubit registers such as ``bit[n] b`` and ``qubit[n] q`` in some
+contexts operate in ways reminiscent of arrays (in particular, indexing is a natural
+operation on such varaibles), variables of neither type are valid arguments to
+``sizeof()``.

--- a/spec_releasenotes/releasenotes/notes/clarify-sizeof-not-on-registers-7a7ebacc1ba9994e.yaml
+++ b/spec_releasenotes/releasenotes/notes/clarify-sizeof-not-on-registers-7a7ebacc1ba9994e.yaml
@@ -1,0 +1,4 @@
+---
+issues:
+  - |
+    Clarified that ``sizeof()`` does not operate on bit or qubit registers.


### PR DESCRIPTION
Fixes #619.