### PR TITLE
Docs: Document sizeof() in types and classical instructions

### DIFF
--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -47,7 +47,8 @@ and ``&``, or ``|``, xor ``^``. They support left shift ``<<`` and right shift
 ``>>`` by an unsigned integer, and the corresponding assignment operators. The
 shift operators shift bits off the end. They also support bitwise negation ``~``,
 ``popcount`` [1]_, and left and right circular shift, ``rotl`` and ``rotr``,
-respectively.
+respectively. For arrays, the ``sizeof()`` [3]_ function can be used to query 
+their dimensions.
 
 .. code-block::
 
@@ -346,7 +347,7 @@ While loops
 ~~~~~~~~~~~
 
 The statement ``while ( bool ) <body>`` executes program until the Boolean evaluates to
-false [3]_. Variables in the loop condition statement may be modified
+false [4]_. Variables in the loop condition statement may be modified
 within the while loop body.  The ``body`` can be either a single statement
 terminated by a semicolon, or a program block in curly braces ``{}`` of several
 statements:
@@ -663,6 +664,11 @@ computation, but does not wait for that computation to terminate.
    instructions.
 
 .. [3]
+   ``sizeof(array)`` or ``sizeof(array, dimension)`` returns the size of the 
+   specified dimension of an array as a ``const uint``. The dimension 
+   parameter is zero-based and defaults to 0 if omitted.
+
+.. [4]
    This clearly allows users to write code that does not terminate. We
    do not discuss implementation details here, but one possibility is to
    compile into target code that imposes iteration limits.

--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -47,8 +47,7 @@ and ``&``, or ``|``, xor ``^``. They support left shift ``<<`` and right shift
 ``>>`` by an unsigned integer, and the corresponding assignment operators. The
 shift operators shift bits off the end. They also support bitwise negation ``~``,
 ``popcount`` [1]_, and left and right circular shift, ``rotl`` and ``rotr``,
-respectively. For arrays, the ``sizeof()`` [3]_ function can be used to query 
-their dimensions.
+respectively. 
 
 .. code-block::
 
@@ -357,7 +356,7 @@ While loops
 ~~~~~~~~~~~
 
 The statement ``while ( bool ) <body>`` executes program until the Boolean evaluates to
-false [4]_. Variables in the loop condition statement may be modified
+false [3]_. Variables in the loop condition statement may be modified
 within the while loop body.  The ``body`` can be either a single statement
 terminated by a semicolon, or a program block in curly braces ``{}`` of several
 statements:
@@ -675,11 +674,6 @@ computation, but does not wait for that computation to terminate.
    instructions.
 
 .. [3]
-   ``sizeof(array)`` or ``sizeof(array, dimension)`` returns the size of the 
-   specified dimension of an array as a ``const uint``. The dimension 
-   parameter is zero-based and defaults to 0 if omitted.
-
-.. [4]
    This clearly allows users to write code that does not terminate. We
    do not discuss implementation details here, but one possibility is to
    compile into target code that imposes iteration limits.

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -823,6 +823,17 @@ the shape and type of the assigned value must match that of the reference.
 
    bb[0] = 1 // error - shape mismatch
 
+The dimensions of arrays can be queried using the built-in ``sizeof()`` 
+function, which takes two parameters: the array being queried, and the 
+zero-based dimension number requested. If the second parameter is omitted, 
+it defaults to ``0``, i.e., ``sizeof(arr) == sizeof(arr, 0)``. 
+
+.. code-block::
+
+   array[int[8], 3, 4] twoD;
+   const uint firstDim = sizeof(twoD);      // 3
+   const uint secondDim = sizeof(twoD, 1);  // 4
+   
 Arrays may be passed to subroutines and externs. For more details, see
 :any:`arrays-in-subroutines`.
 

--- a/spec_releasenotes/releasenotes/notes/expand-sizeof-documentation-e0f49617d457199e.yaml
+++ b/spec_releasenotes/releasenotes/notes/expand-sizeof-documentation-e0f49617d457199e.yaml
@@ -1,0 +1,8 @@
+---
+other:
+  - |
+    Added documentation on the :func:`sizeof()` built-in function for querying array dimensions in two sections:
+
+    - **Classical instructions** -> *Classical bits and registers*
+    - **Types and casting** -> *Arrays*
+

--- a/spec_releasenotes/releasenotes/notes/expand-sizeof-documentation-e0f49617d457199e.yaml
+++ b/spec_releasenotes/releasenotes/notes/expand-sizeof-documentation-e0f49617d457199e.yaml
@@ -1,7 +1,7 @@
 ---
 other:
   - |
-    Added documentation on the :func:`sizeof()` built-in function for querying array dimensions in two sections:
+    Added documentation on the `sizeof()` built-in function for querying array dimensions in two sections:
 
     - **Classical instructions** -> *Classical bits and registers*
     - **Types and casting** -> *Arrays*


### PR DESCRIPTION
### Summary
This PR adds documentation on the `sizeof()` built-in function for querying array dimensions in two locations:
- `Classical instructions` section `Classical bits and registers`
- `Types and casting` section `Arrays`

Thus far it was only documented in `Subroutines` and in `arrays.qasm` examples

### Details and comments
- Added `sizeof()` function description to the classical operations section (`source/language/classical.rst:50`)
- Added detailed footnote explaining `sizeof()` syntax and behavior (`source/language/classical.rst:666-670`)
- Added usage examples in the arrays section (`source/language/types.rst:826-837`)

