### PR TITLE
Fix/mypy issues

### DIFF
--- a/source/openqasm/openqasm3/_antlr/__init__.py
+++ b/source/openqasm/openqasm3/_antlr/__init__.py
@@ -65,4 +65,4 @@ RUNTIME_VERSION = tuple(int(x) for x in _parts)
 
 # These imports are re-directed into concrete versioned ones.  Doing them
 # manually here helps stop pylint complaining.
-from . import qasm3Lexer, qasm3Parser, qasm3ParserVisitor, qasm3ParserListener
+from . import qasm3Lexer, qasm3Parser, qasm3ParserVisitor, qasm3ParserListener  # type: ignore[attr-defined]

--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -102,7 +102,7 @@ __all__ = [
 AccessControl = Enum("AccessControl", "readonly mutable")
 AssignmentOperator = Enum("AssignmentOperator", "= += -= *= /= &= |= ^= <<= >>= %= **=")
 BinaryOperator = Enum("BinaryOperator", "> < >= <= == != && || | ^ & << >> + - * / % **")
-GateModifierName = Enum("GateModifier", "inv pow ctrl negctrl")
+GateModifierName = Enum("GateModifierName", "inv pow ctrl negctrl")
 IOKeyword = Enum("IOKeyword", "input output")
 TimeUnit = Enum("TimeUnit", "dt ns us ms s")
 UnaryOperator = Enum("UnaryOperator", "~ ! -")

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -130,7 +130,7 @@ def get_span(node: Union[ParserRuleContext, TerminalNode]) -> ast.Span:
     if isinstance(node, ParserRuleContext):
         return ast.Span(node.start.line, node.start.column, node.stop.line, node.stop.column)
     else:
-        return ast.Span(node.symbol.line, node.symbol.start, node.symbol.line, node.symbol.stop)
+        return ast.Span(node.symbol.line, node.symbol.start, node.symbol.line, node.symbol.stop)  # type: ignore[attr-defined]
 
 
 def get_comments(input_: str) -> List[dict]:
@@ -201,7 +201,7 @@ def span(func):
 
 
 def _visit_identifier(identifier: TerminalNode):
-    return add_span(ast.Identifier(identifier.getText()), get_span(identifier))
+    return add_span(ast.Identifier(identifier.getText()), get_span(identifier))  # type: ignore[attr-defined]
 
 
 def _raise_from_context(ctx: ParserRuleContext, message: str):

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -293,7 +293,7 @@ class QASMNodeVisitor(qasm3ParserVisitor):
         if not self._in_global_scope():
             _raise_from_context(ctx, "pragmas must be global")
         return ast.Pragma(
-            command=ctx.RemainingLineContent().getText() if ctx.RemainingLineContent() else None
+            command=ctx.RemainingLineContent().getText() if ctx.RemainingLineContent() else ""
         )
 
     @span

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -658,7 +658,7 @@ class QASMNodeVisitor(qasm3ParserVisitor):
         )
 
     @span
-    def _visit_binary_expression(self, ctx: ParserRuleContext):
+    def _visit_binary_expression(self, ctx: qasm3Parser.ParserRuleContext):
         return ast.BinaryExpression(
             lhs=self.visit(ctx.expression(0)),
             op=ast.BinaryOperator[ctx.op.text],

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -34,7 +34,7 @@ __all__ = [
 ]
 
 from contextlib import contextmanager
-from typing import Union, TypeVar, List, Optional
+from typing import Union, TypeVar, List, Optional, cast
 
 try:
     from antlr4 import CommonTokenStream, InputStream, ParserRuleContext, RecognitionException
@@ -331,7 +331,7 @@ class QASMNodeVisitor(qasm3ParserVisitor):
     def visitBoxStatement(self, ctx: qasm3Parser.BoxStatementContext):
         return ast.Box(
             duration=self.visit(ctx.designator()) if ctx.designator() else None,
-            body=self._parse_scoped_statements(ctx.scope()),
+            body=cast(List[ast.QuantumStatement], self._parse_scoped_statements(ctx.scope())),
         )
 
     @span
@@ -513,7 +513,7 @@ class QASMNodeVisitor(qasm3ParserVisitor):
         )
         qubits = [_visit_identifier(id_) for id_ in ctx.qubits.Identifier()]
         with self._push_context(ctx):
-            body = self._parse_scoped_statements(ctx.scope())
+            body = cast(List[ast.QuantumStatement], self._parse_scoped_statements(ctx.scope()))
         return ast.QuantumGateDefinition(name, arguments, qubits, body)
 
     @span

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -48,9 +48,9 @@ except ImportError as exc:
         " such as by 'pip install openqasm3[parser]'."
     ) from exc
 
-from ._antlr.qasm3Lexer import qasm3Lexer
-from ._antlr.qasm3Parser import qasm3Parser
-from ._antlr.qasm3ParserVisitor import qasm3ParserVisitor
+from ._antlr.qasm3Lexer import qasm3Lexer  # type: ignore[import-not-found]
+from ._antlr.qasm3Parser import qasm3Parser  # type: ignore[import-not-found]
+from ._antlr.qasm3ParserVisitor import qasm3ParserVisitor  # type: ignore[import-not-found]
 from . import ast
 
 _TYPE_NODE_INIT = {

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -283,7 +283,7 @@ class QASMNodeVisitor(qasm3ParserVisitor):
         )
 
     @span
-    def visitScope(self, ctx: qasm3Parser.ScopeContext) -> List[ast.Statement]:
+    def visitScope(self, ctx: qasm3Parser.ScopeContext) -> ast.CompoundStatement:
         return ast.CompoundStatement(
             statements=[self.visit(statement) for statement in ctx.statementOrScope()]
         )

--- a/source/openqasm/openqasm3/parser.py
+++ b/source/openqasm/openqasm3/parser.py
@@ -941,6 +941,7 @@ class QASMNodeVisitor(qasm3ParserVisitor):
                 name=name, size=self.visit(designator) if designator else None
             )
         access = None
+        type_: ast.ClassicalType
         if ctx.CREG():
             size = self.visit(ctx.designator()) if ctx.designator() else None
             creg_span = get_span(ctx.CREG())
@@ -974,6 +975,7 @@ class QASMNodeVisitor(qasm3ParserVisitor):
     @span
     def visitExternArgument(self, ctx: qasm3Parser.ExternArgumentContext):
         access = None
+        type_: ast.ClassicalType
         if ctx.CREG():
             type_ = ast.BitType(size=self.visit(ctx.designator()) if ctx.designator() else None)
         elif ctx.scalarType():

--- a/source/openqasm/openqasm3/printer.py
+++ b/source/openqasm/openqasm3/printer.py
@@ -218,7 +218,7 @@ class Printer(QASMVisitor[PrinterState]):
         self._end_statement(context)
 
     def _visit_statement_list(
-        self, nodes: List[ast.Statement], context: PrinterState, prefix: str = ""
+        self, nodes: Sequence[ast.Statement], context: PrinterState, prefix: str = ""
     ) -> None:
         self.stream.write(prefix)
         self.stream.write("{")


### PR DESCRIPTION
### Summary
This PR fixes the existing MyPy issues. Most of the fixes were entirely obvious, but some, highlighted with **Alternative**, are less obvious.



### Details and comments

#### Issue 1
**Cause:** `ast.GateModifierName` has differing name `GateModifier`
**Fix:** Changed the enum name `GateModifier` -> `GateModifierName`
**Consequences**: No functional change.

#### Issue 2
**Cause**: `ast.Pragma.command` expects `str`, but `visitPragma` returns `None` if there is no `RemainingLineContent`
**Fix:** visitPragma now returns empty string if there is no `RemainingLineContent`
**Consequences**: Could lead to issues if any users explicitly check whether `if visitPragma.command is None` (unlikely)

#### Issue 3
**Cause**: `ast.Box.body` expects `list[QuantumStatement]`, but `visitBox` returns `list[Statement]`
**Fix:** Changed the type to `list[QuantumStatement]` per mypy suggestion
**Consequences**: No functional change.

#### Issue 4
**Cause**: `visitScope` was annotated to return `List[Statement]`, but returns `ast.CompoundStatement`
**Fix:** Updated the return type annotation to `ast.CompoundStatement`
**Consequences**: No functional change.

#### Issue 5
**Cause**: The ANTLR runtime types in the available stubs do not expose `.symbol` or `.getText`, so mypy flagged attribute accesses on `TerminalNode`.
**Fix:** Added `# type: ignore[attr-defined]` to the few locations that rely on those attributes, documenting that the runtime does provide them.
**Consequences**: No behaviour change as I believe static typing cannot verify these attributes
**Alternative**: Add `.symbol` and `.getText` to the stubs

#### Issue 6
**Cause**: Mypy could not find stubs for the generated `qasm3Lexer`, `qasm3Parser`, and `qasm3ParserVisitor`, and gave an error that `_antlr` might not expose `qasm3ParserListener`.
**Fix**: Suppressed the error by adding `# type: ignore[import-not-found]`
**Consequences**: No functional change.
**Alternative**: Perhaps there is an alternative solution? It seems to be an issue caused by the dynamic package lookup.

#### Issue 7
**Cause**: Inconsistent typing of `type_` variable in `visitExternArgument` and `visitArgumentDefinition`
**Fix**: Annotated `type_` variable as `ast.ClassicalType`
**Consequences**: No functional change.

#### Issue 8
**Cause**: `visitGateStatement` and `visitBoxStatement` expected `List[QuantumStatement]` in body rather than more general `List[Statement]`
**Fix**: Cast gate and box bodies to `List[QuantumStatement]`
**Consequences**: No functional change.
**Alternative**: None that I can think of, is there any situation where it wouldn't be a `List[QuantumStatement]`?

#### Issue 9
**Cause**: `_visit_binary_expression` had `ctx: qasm3Parser.ParserRuleContext` instead of `qasm3Parser.ParserRuleContext`
**Fix**: Changed the type to `qasm3Parser.ParserRuleContext`
**Consequences**: No functional change.


### Original list of errors
```
❯ mypy openqasm3
openqasm3/ast.py:105: error: String argument 1 "GateModifier" to enum.Enum(...) does not match variable name "GateModifierName"  [misc]
openqasm3/_antlr/__init__.py:68: error: Module "openqasm3._antlr" has no attribute "qasm3ParserListener"; maybe "qasm3ParserVisitor"?  [attr-defined]
openqasm3/parser.py:51: error: Cannot find implementation or library stub for module named "openqasm3._antlr.qasm3Lexer"  [import-not-found]
openqasm3/parser.py:51: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
openqasm3/parser.py:52: error: Cannot find implementation or library stub for module named "openqasm3._antlr.qasm3Parser"  [import-not-found]
openqasm3/parser.py:53: error: Cannot find implementation or library stub for module named "openqasm3._antlr.qasm3ParserVisitor"  [import-not-found]
openqasm3/parser.py:133: error: "TerminalNode" has no attribute "symbol"  [attr-defined]
openqasm3/parser.py:204: error: "TerminalNode" has no attribute "getText"  [attr-defined]
openqasm3/parser.py:218: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
openqasm3/parser.py:287: error: Incompatible return value type (got "CompoundStatement", expected "list[Statement]")  [return-value]
openqasm3/parser.py:296: error: Argument "command" to "Pragma" has incompatible type "Any | None"; expected "str"  [arg-type]
openqasm3/parser.py:334: error: Argument "body" to "Box" has incompatible type "list[Statement]"; expected "list[QuantumStatement]"  [arg-type]
openqasm3/parser.py:517: error: Argument 4 to "QuantumGateDefinition" has incompatible type "list[Statement]"; expected "list[QuantumStatement]"  [arg-type]
openqasm3/parser.py:663: error: "ParserRuleContext" has no attribute "expression"  [attr-defined]
openqasm3/parser.py:664: error: "ParserRuleContext" has no attribute "op"  [attr-defined]
openqasm3/parser.py:665: error: "ParserRuleContext" has no attribute "expression"  [attr-defined]
openqasm3/parser.py:962: error: Incompatible types in assignment (expression has type "ArrayReferenceType", variable has type "BitType")  [assignment]
openqasm3/parser.py:992: error: Incompatible types in assignment (expression has type "ArrayReferenceType", variable has type "BitType")  [assignment]
openqasm3/printer.py:298: error: Argument 1 to "_visit_statement_list" of "Printer" has incompatible type "list[QuantumStatement]"; expected "list[Statement]"  [arg-type]
openqasm3/printer.py:298: note: "list" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
openqasm3/printer.py:298: note: Consider using "Sequence" instead, which is covariant
openqasm3/printer.py:820: error: Argument 1 to "_visit_statement_list" of "Printer" has incompatible type "list[QuantumStatement]"; expected "list[Statement]"  [arg-type]
openqasm3/printer.py:820: note: "list" is invariant -- see https://mypy.readthedocs.io/en/stable/common_issues.html#variance
openqasm3/printer.py:820: note: Consider using "Sequence" instead, which is covariant
Found 18 errors in 4 files (checked 8 source files)
```