### PR TITLE
Docs: Fixes explicit state mapping for rz gate

### DIFF
--- a/releasenotes/notes/fix-docs-rz-gate-state-mapping-1b01bff2e5f233cd.yaml
+++ b/releasenotes/notes/fix-docs-rz-gate-state-mapping-1b01bff2e5f233cd.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Corrected the explicit state mapping for the rz gate given in the docs (source/language/standard_library.rst).

--- a/source/language/standard_library.rst
+++ b/source/language/standard_library.rst
@@ -238,8 +238,8 @@ Single-qubit gates
    .. math::
 
       \texttt{rz(θ) a;} \mapsto \mathit{RZ}(\theta)\colon\ \left\{\begin{aligned}[c]
-         \lvert0\rangle &\to \cos(\theta/2)\lvert0\rangle + \sin(\theta/2)\lvert1\rangle\\
-         \lvert1\rangle &\to \sin(\theta/2)\lvert0\rangle - \cos(\theta/2)\lvert1\rangle.
+         \lvert0\rangle &\to \exp(-i\theta/2)\lvert0\rangle \\
+         \lvert1\rangle &\to \exp(\phantom{-} i\theta/2)\lvert1\rangle.
       \end{aligned}\right.
 
    .. seealso::


### PR DESCRIPTION
### Summary
Corrects the explicit state mapping of the rz gate given in the documentation. 
Fixes #660 

### Details and comments
The rz gate is defined as `rz(θ)=exp(-iZθ/2)`, where `Z` is the Pauli Z matrix. Therefore, mapping state `|0>` should result in a zero amplitude for state `|1>` and vice versa.

<img width="519" height="115" alt="image" src="https://github.com/user-attachments/assets/214e82e4-86bc-4945-8274-42f5f4749dfc" />
