### PR TITLE
Add blanket statement allowing trailing commas

### DIFF
--- a/source/grammar/tests/reference/trailing_commas/array.yaml
+++ b/source/grammar/tests/reference/trailing_commas/array.yaml
@@ -1,0 +1,30 @@
+# indent w/ 2 spaces
+source: |
+  array[int[8], 4, 3,] bb;
+reference: |
+  program
+    statementOrScope
+      statement
+        classicalDeclarationStatement
+          arrayType
+            array
+            [
+            scalarType
+              int
+              designator
+                [
+                expression
+                  8
+                ]
+            ,
+            expressionList
+              expression
+                4
+              ,
+              expression
+                3
+              ,
+            ]
+          bb
+          ;
+    <EOF>

--- a/source/grammar/tests/reference/trailing_commas/extern.yaml
+++ b/source/grammar/tests/reference/trailing_commas/extern.yaml
@@ -1,6 +1,6 @@
 # indent w/ 2 spaces
 source: |
-  extern fun(int) -> int;
+  extern fun(int, int,) -> int;
 reference: |
   program
     statementOrScope

--- a/source/grammar/tests/reference/trailing_commas/extern.yaml
+++ b/source/grammar/tests/reference/trailing_commas/extern.yaml
@@ -1,0 +1,27 @@
+# indent w/ 2 spaces
+source: |
+  extern fun(int) -> int;
+reference: |
+  program
+    statementOrScope
+      statement
+        externStatement
+          extern
+          fun
+          (
+          externArgumentList
+            externArgument
+              scalarType
+                int
+            ,
+            externArgument
+              scalarType
+                int
+            ,
+          )
+          returnSignature
+            ->
+            scalarType
+              int
+          ;
+    <EOF>

--- a/source/grammar/tests/reference/trailing_commas/gate.yaml
+++ b/source/grammar/tests/reference/trailing_commas/gate.yaml
@@ -1,0 +1,32 @@
+# indent w/ 2 spaces
+source: |
+  gate g a, b,
+  {
+     CX a, b;
+  }
+reference: |
+  program
+    statementOrScope
+      statement
+        gateStatement
+          gate
+          g
+          identifierList
+            a
+            ,
+            b
+            ,
+          {
+          gateCallStatement
+            CX
+            gateOperandList
+              gateOperand
+                indexedIdentifier
+                  a
+              ,
+              gateOperand
+                indexedIdentifier
+                  b
+            ;
+          }
+    <EOF>

--- a/source/grammar/tests/reference/trailing_commas/gate.yaml
+++ b/source/grammar/tests/reference/trailing_commas/gate.yaml
@@ -16,17 +16,20 @@ reference: |
             ,
             b
             ,
-          {
-          gateCallStatement
-            CX
-            gateOperandList
-              gateOperand
-                indexedIdentifier
-                  a
-              ,
-              gateOperand
-                indexedIdentifier
-                  b
-            ;
-          }
+          scope
+            {
+            statementOrScope
+              statement
+                gateCallStatement
+                  CX
+                  gateOperandList
+                    gateOperand
+                      indexedIdentifier
+                        a
+                    ,
+                    gateOperand
+                      indexedIdentifier
+                        b
+                  ;
+            }
     <EOF>

--- a/source/grammar/tests/reference/trailing_commas/index.yaml
+++ b/source/grammar/tests/reference/trailing_commas/index.yaml
@@ -1,0 +1,32 @@
+# indent w/ 2 spaces
+source: |
+  let qubit_selection = two[{0, 3, 5, }];
+reference: |
+  program
+    statementOrScope
+      statement
+        aliasDeclarationStatement
+          let
+          qubit_selection
+          =
+          aliasExpression
+            expression
+              expression
+                two
+              indexOperator
+                [
+                setExpression
+                  {
+                  expression
+                    0
+                  ,
+                  expression
+                    3
+                  ,
+                  expression
+                    5
+                  ,
+                  }
+                ]
+          ;
+    <EOF>

--- a/source/grammar/tests/reference/trailing_commas/nop.yaml
+++ b/source/grammar/tests/reference/trailing_commas/nop.yaml
@@ -1,0 +1,20 @@
+# indent w/ 2 spaces
+source: |
+  nop q1, q2,;
+reference: |
+  program
+    statementOrScope
+      statement
+        nopStatement
+          nop
+          gateOperandList
+            gateOperand
+              indexedIdentifier
+                q1
+            ,
+            gateOperand
+              indexedIdentifier
+                q2
+            ,
+          ;
+    <EOF>

--- a/source/language/index.rst
+++ b/source/language/index.rst
@@ -8,6 +8,7 @@ OpenQASM Version 3.0.
 
 The human-readable form of OpenQASM is a simple, case-sensitive textual language.
 Statements are separated by semicolons and whitespace is ignored.
+A non-empty comma-separated list may end with a single trailing comma.
 
 In other respects, OpenQASM possesses a dual nature as an assembly language and
 as a hardware description language.

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -430,10 +430,10 @@ type).  All scalar literals are ``const`` types.
 .. code-block::
 
    // Valid statements
-   
+
    const uint SIZE = 32;  // Declares a compile-time unsigned integer.
 
-   qubit[SIZE] q1;  // Declares a 32-qubit register called `q1`. 
+   qubit[SIZE] q1;  // Declares a 32-qubit register called `q1`.
    int[SIZE] i1;    // Declares a signed integer called `i1` with 32 bits.
 
 
@@ -792,7 +792,7 @@ last, and so on, with ``-n`` being the first element of an n-element array.
 Multi-dimensional arrays (as in the example above) are allowed, with a maximum
 of 7 total dimensions. The subscript operator ``[]`` is used for element access,
 and for multi-dimensional arrays subarray accesses can be specified using a
-comma-delimited list of indices (*e.g.* ``myArr[1, 2, 3]``), with the outer
+comma-separated list of indices (*e.g.* ``myArr[1, 2, 3]``), with the outer
 dimension specified first.
 
 One or more dimension(s) of an array can be zero, in which case the array has size zero.  An array of size zero cannot be indexed, e.g. given ``array[float[32], 0] myArray;``, it is an error to access either ``myArray[0]`` or ``myArray[-1]``.
@@ -935,7 +935,7 @@ always returns a bit array of size equal to the size of the index set.
    myInt[4:7] = "1010"; // myInt == 0xAF
 
 Bit-level access is still possible with elements of arrays. It is suggested that
-multi-dimensional access be done using the comma-delimited version of the
+multi-dimensional access be done using the comma-separated version of the
 subscript operator to reduce confusion. With this convention nearly all
 instances of multiple subscripts ``[][]`` will be bit-level accesses of array
 elements.
@@ -983,8 +983,8 @@ should be explicitly declared and assigned the concatenation.
    subroutine_call(first ++ third) // forbidden
    subroutine_call(selfConcat) // allowed
 
-Arrays can be sliced just like quantum registers using a range ``a:b:c`` 
-and can be indexed using an integer but cannot be indexed by a a comma-separated 
+Arrays can be sliced just like quantum registers using a range ``a:b:c``
+and can be indexed using an integer but cannot be indexed by a comma-separated
 list of integers contained in braces ``{a,b,c,…}``. Slicing uses
 the subscript operator ``[]``, but produces an array (or reference in the case
 of assignment) with the same number of dimensions as the given identifier.
@@ -1182,4 +1182,3 @@ dividing a duration by a duration produces a machine-precision ``float``.
 
    duration one_s = 1s;
    float a_in_s = a / one_s; // 5e-7
-

--- a/spec_releasenotes/releasenotes/notes/allow-trailing-commas-884ff06ac78a1181.yaml
+++ b/spec_releasenotes/releasenotes/notes/allow-trailing-commas-884ff06ac78a1181.yaml
@@ -1,0 +1,6 @@
+---
+features:
+  - |
+    Trailing commas are now explicitly allowed in comma-separated lists. The reference
+    parser already allows trailing commas. Previously, the specification was silent on
+    trailing commas.


### PR DESCRIPTION
### Summary

This PR changes the specification by stating that an optional trailing comma is allowed in comma-separated lists.


### Details and comments

Instead of a single blanket statement, we could modify every statement that specifies a comma separated list. That would be more explicit, but significantly more cumbersome. It seems to me that a single statement is a better choice.

* A typo is corrected in a file touched by this PR.
* Trailing whitespace is removed in files touched by this PR.
* Two occurrences of  "comma-delimited" are replaced by "comma-separated".

closes #643