### PR TITLE
Docs: Updated the source/language/classical.rst to make description of while more precise

### DIFF
--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -355,8 +355,8 @@ accessible after the loop.
 While loops
 ~~~~~~~~~~~
 
-The statement ``while ( bool ) <body>`` executes program until the Boolean evaluates to
-false [3]_. Variables in the loop condition statement may be modified
+The statement ``while ( <condition> ) <body>`` repeatedly executes ``<body>`` as long as
+the condition evaluates to true [3]_. Variables in the loop condition statement may be modified
 within the while loop body.  The ``body`` can be either a single statement
 terminated by a semicolon, or a program block in curly braces ``{}`` of several
 statements:

--- a/spec_releasenotes/releasenotes/notes/while-loop-description-20e0337dd9f44647.yaml
+++ b/spec_releasenotes/releasenotes/notes/while-loop-description-20e0337dd9f44647.yaml
@@ -1,0 +1,8 @@
+---
+features:
+  - |
+    Clarified the description of the ``while`` loop semantics in the classical
+    language specification.  The condition is now consistently referred to as
+    ``<condition>`` and the description states that ``<body>`` is repeatedly
+    executed as long as the condition evaluates to ``true``, matching the
+    standard pre-check semantics.  See :ref:`while-loops` for details.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Closes #670. Corrects the `while` loop description in `source/language/classical.rst`:

- Use `<condition>` instead of `bool` as the metavariable placeholder
- Rephrase to correctly describe pre-check semantics: "repeatedly executes `<body>` as long as the condition evaluates to true"
- Use `<body>` instead of "program" for consistency with the rest of the spec

### Details and comments

No grammar changes. Docs-only fix to align the while loop description with the existing `for` loop conventions and the actual semantics of the language.